### PR TITLE
Fixed spyglass insert functions

### DIFF
--- a/src/jadhav_lab_to_nwb/spyglass_mock/dj_local_conf.json
+++ b/src/jadhav_lab_to_nwb/spyglass_mock/dj_local_conf.json
@@ -15,7 +15,7 @@
     "database.use_tls": false,
     "enable_python_native_blobs": true,
     "add_hidden_timestamp": false,
-    "filepath_checksum_size_limit": 1073741824,
+    "filepath_checksum_size_limit": 3221225472,
     "stores": {
         "raw": {
             "protocol": "file",


### PR DESCRIPTION
spyglass insert functions were failing with the full-sized example .nwb file due to inefficient memory usage. Now, everything is chunked properly and loads into spyglass.