### PR TITLE
Convert all sessions

### DIFF
--- a/src/jadhav_lab_to_nwb/datainterfaces/base_dlc_interface.py
+++ b/src/jadhav_lab_to_nwb/datainterfaces/base_dlc_interface.py
@@ -7,8 +7,6 @@ from neuroconv.utils import DeepDict, dict_deep_update
 from neuroconv.basedatainterface import BaseDataInterface
 from neuroconv.datainterfaces import DeepLabCutInterface
 
-from ..utils.utils import rivera_and_shukla_2025_get_epoch_name
-
 
 class BaseDeepLabCutInterface(BaseDataInterface):
     """DeepLabCut interface for rivera_and_shukla_2025 conversion"""

--- a/src/jadhav_lab_to_nwb/datainterfaces/base_dlc_interface.py
+++ b/src/jadhav_lab_to_nwb/datainterfaces/base_dlc_interface.py
@@ -2,7 +2,6 @@
 from abc import abstractmethod
 from pynwb.file import NWBFile
 from pydantic import FilePath
-from typing import Optional
 
 from neuroconv.utils import DeepDict, dict_deep_update
 from neuroconv.basedatainterface import BaseDataInterface
@@ -18,31 +17,37 @@ class BaseDeepLabCutInterface(BaseDataInterface):
 
     def __init__(
         self,
-        file_paths: list[FilePath],
-        config_file_paths: Optional[list[FilePath]] = None,
+        file_paths: list[list[FilePath] | FilePath],
+        config_file_paths: list[list[FilePath] | FilePath] | None = None,
         subject_id: str | None = None,
         verbose: bool = True,
     ):
         # file_paths must be sorted in the order that the videos were recorded
         assert len(file_paths) > 0, "At least one file path must be provided."
         if config_file_paths is None:
-            config_file_paths = [None] * len(file_paths)
+            config_file_paths = [[None] * len(fp) if isinstance(fp, list) else None for fp in file_paths]
         msg = "The number of file paths must match the number of config file paths."
         assert len(file_paths) == len(config_file_paths), msg
         dlc_interfaces = []
-        for file_path, config_file_path in zip(file_paths, config_file_paths):
-            subject_name = self.get_subject_name(file_name=file_path.name, subject_id=subject_id)
-            pose_estimation_metadata_key = self.get_pose_estimation_metadata_key(
-                file_name=file_path.name, subject_id=subject_id
-            )
-            dlc_interface = DeepLabCutInterface(
-                file_path=file_path,
-                config_file_path=config_file_path,
-                subject_name=subject_name,
-                pose_estimation_metadata_key=pose_estimation_metadata_key,
-                verbose=verbose,
-            )
-            dlc_interfaces.append(dlc_interface)
+        for epoch_file_paths, epoch_config_file_paths in zip(file_paths, config_file_paths):
+            if not isinstance(epoch_file_paths, list):
+                epoch_file_paths = [epoch_file_paths]
+            if not isinstance(epoch_config_file_paths, list):
+                epoch_config_file_paths = [epoch_config_file_paths]
+            assert len(epoch_file_paths) == len(epoch_config_file_paths), msg
+            for file_path, config_file_path in zip(epoch_file_paths, epoch_config_file_paths):
+                subject_name = self.get_subject_name(file_name=file_path.name, subject_id=subject_id)
+                pose_estimation_metadata_key = self.get_pose_estimation_metadata_key(
+                    file_name=file_path.name, subject_id=subject_id
+                )
+                dlc_interface = DeepLabCutInterface(
+                    file_path=file_path,
+                    config_file_path=config_file_path,
+                    subject_name=subject_name,
+                    pose_estimation_metadata_key=pose_estimation_metadata_key,
+                    verbose=verbose,
+                )
+                dlc_interfaces.append(dlc_interface)
         self.dlc_interfaces = dlc_interfaces
 
     @abstractmethod

--- a/src/jadhav_lab_to_nwb/datainterfaces/base_epoch_interface.py
+++ b/src/jadhav_lab_to_nwb/datainterfaces/base_epoch_interface.py
@@ -58,7 +58,9 @@ class BaseEpochInterface(BaseTemporalAlignmentInterface):
             led_configuration = task_metadata["led_configuration"]
             led_list = ",".join(task_metadata["led_list"])
             led_positions = ",".join(task_metadata["led_positions"])
-            task_epochs = task_metadata["task_epochs"]
+            task_epochs = task_metadata.get("task_epochs", [])
+            if len(task_epochs) == 0:
+                continue  # Skip tasks with no epochs
             task_table = DynamicTable(name=name, description=description)
             task_table.add_column(name="task_name", description="Name of the task.")
             task_table.add_column(name="task_description", description="Description of the task.")

--- a/src/jadhav_lab_to_nwb/datainterfaces/base_epoch_interface.py
+++ b/src/jadhav_lab_to_nwb/datainterfaces/base_epoch_interface.py
@@ -2,7 +2,7 @@
 from abc import abstractmethod
 from pynwb.file import NWBFile
 from pynwb.core import DynamicTable
-from pydantic import DirectoryPath
+from pydantic import FilePath
 import numpy as np
 from copy import deepcopy
 
@@ -16,7 +16,7 @@ class BaseEpochInterface(BaseTemporalAlignmentInterface):
 
     keywords = ("behavior",)
 
-    def __init__(self, video_timestamps_file_paths: list[DirectoryPath]):
+    def __init__(self, video_timestamps_file_paths: list[FilePath | list[FilePath]]):
         super().__init__(video_timestamps_file_paths=video_timestamps_file_paths)
         self.timestamps = None
 
@@ -90,17 +90,22 @@ class BaseEpochInterface(BaseTemporalAlignmentInterface):
     ):
         pass
 
-    def get_original_timestamps(self) -> list[np.ndarray]:
+    def get_original_timestamps(self) -> list[list[np.ndarray]]:
         """Get the original timestamps for the video files."""
         video_timestamps_file_paths = self.source_data["video_timestamps_file_paths"]
         original_timestamps = []
-        for video_timestamps_file_path in video_timestamps_file_paths:
-            timestamps, _ = readCameraModuleTimeStamps(video_timestamps_file_path)
-            original_timestamps.append(timestamps)
+        for epoch_video_timestamps_file_paths in video_timestamps_file_paths:
+            if not isinstance(epoch_video_timestamps_file_paths, list):
+                epoch_video_timestamps_file_paths = [epoch_video_timestamps_file_paths]
+            original_epoch_timestamps = []
+            for video_timestamps_file_path in epoch_video_timestamps_file_paths:
+                timestamps, _ = readCameraModuleTimeStamps(video_timestamps_file_path)
+                original_epoch_timestamps.append(timestamps)
+            original_timestamps.append(original_epoch_timestamps)
         return original_timestamps
 
-    def get_timestamps(self) -> list[np.ndarray]:
+    def get_timestamps(self) -> list[list[np.ndarray]]:
         return self.timestamps if self.timestamps is not None else self.get_original_timestamps()
 
-    def set_aligned_timestamps(self, aligned_timestamps: list[np.ndarray]):
+    def set_aligned_timestamps(self, aligned_timestamps: list[list[np.ndarray]]):
         self.timestamps = aligned_timestamps

--- a/src/jadhav_lab_to_nwb/olson_2024/olson_2024_convert_session.py
+++ b/src/jadhav_lab_to_nwb/olson_2024/olson_2024_convert_session.py
@@ -2,12 +2,8 @@
 from pathlib import Path
 from datetime import datetime
 from zoneinfo import ZoneInfo
-import shutil
 from natsort import natsorted
 
-from ndx_pose import (
-    PoseEstimationSeries,
-)  # TODO: remove after this issue gets fixed: https://github.com/catalystneuro/neuroconv/issues/1143
 from neuroconv.utils import load_dict_from_file, dict_deep_update
 
 from jadhav_lab_to_nwb.olson_2024 import Olson2024NWBConverter

--- a/src/jadhav_lab_to_nwb/olson_2024/olson_2024_convert_session.py
+++ b/src/jadhav_lab_to_nwb/olson_2024/olson_2024_convert_session.py
@@ -127,7 +127,7 @@ if __name__ == "__main__":
     # Parameters for conversion
     data_dir_path = Path("/Volumes/T7/CatalystNeuro/Jadhav/SubLearnProject")
     output_dir_path = Path("/Volumes/T7/CatalystNeuro/Spyglass/raw")
-    stub_test = True
+    stub_test = False
 
     # Example Session
     subject_id = "SL18"

--- a/src/jadhav_lab_to_nwb/olson_2024/olson_2024_convert_session.py
+++ b/src/jadhav_lab_to_nwb/olson_2024/olson_2024_convert_session.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from datetime import datetime
 from zoneinfo import ZoneInfo
 import shutil
+from natsort import natsorted
 
 from ndx_pose import (
     PoseEstimationSeries,
@@ -47,7 +48,7 @@ def session_to_nwb(
 
     # Get epoch info
     epoch_folder_paths = list(session_folder_path.glob(rf"{session_folder_path.name}_S[0-9][0-9]_F[0-9][0-9]_*"))
-    epoch_folder_paths = sorted(epoch_folder_paths)
+    epoch_folder_paths = natsorted(epoch_folder_paths)
 
     source_data = dict()
     conversion_options = dict()

--- a/src/jadhav_lab_to_nwb/olson_2024/olson_2024_convert_session.py
+++ b/src/jadhav_lab_to_nwb/olson_2024/olson_2024_convert_session.py
@@ -123,7 +123,7 @@ if __name__ == "__main__":
     # Parameters for conversion
     data_dir_path = Path("/Volumes/T7/CatalystNeuro/Jadhav/SubLearnProject")
     output_dir_path = Path("/Volumes/T7/CatalystNeuro/Spyglass/raw")
-    stub_test = False
+    stub_test = True
 
     # Example Session
     subject_id = "SL18"

--- a/src/jadhav_lab_to_nwb/olson_2024/olson_2024_epoch_interface.py
+++ b/src/jadhav_lab_to_nwb/olson_2024/olson_2024_epoch_interface.py
@@ -14,8 +14,8 @@ class Olson2024EpochInterface(BaseEpochInterface):
         for epoch_timestamps, video_timestamps_file_path in zip(timestamps, video_timestamps_file_paths):
             epoch_name = olson_2024_get_epoch_name(video_timestamps_file_path.name)
             epoch_id, _, _, _ = epoch_name.split("_")
-            start_time = epoch_timestamps[0]
-            stop_time = epoch_timestamps[-1]
+            start_time = epoch_timestamps[0][0]
+            stop_time = epoch_timestamps[-1][-1]
             tag = epoch_id[1:]  # from S01 to 01
             epoch_number = int(tag)
             if "SLP" in epoch_name:

--- a/src/jadhav_lab_to_nwb/olson_2024/olson_2024_spike_gadgets_recording_interface.py
+++ b/src/jadhav_lab_to_nwb/olson_2024/olson_2024_spike_gadgets_recording_interface.py
@@ -223,7 +223,7 @@ class Olson2024SingleEpochSpikeGadgetsRecordingInterface(SpikeGadgetsRecordingIn
         # from BaseRecordingExtractorInterface
         from ..tools.spikeinterface import add_recording_to_nwbfile, get_electrical_series_kwargs
 
-        if stub_test or self.subset_channels is not None:
+        if stub_test:
             recording = self.subset_recording(stub_test=stub_test)
         else:
             recording = self.recording_extractor

--- a/src/jadhav_lab_to_nwb/rivera_and_shukla_2025/rivera_and_shukla_2025_behavior_interface.py
+++ b/src/jadhav_lab_to_nwb/rivera_and_shukla_2025/rivera_and_shukla_2025_behavior_interface.py
@@ -62,7 +62,7 @@ class RiveraAndShukla2025BehaviorInterface(BaseDataInterface):
                 lines = file.readlines()
             for i, line in enumerate(lines):
                 line = line.strip()
-                if line.startswith("#"):
+                if line.startswith("#") or line == "~~~":
                     continue  # skip comments
                 timestamp, event_id = line.split(" ", 1)
                 timestamp = float(timestamp) / clock_rate + starting_time_shift

--- a/src/jadhav_lab_to_nwb/rivera_and_shukla_2025/rivera_and_shukla_2025_convert_all_sessions.py
+++ b/src/jadhav_lab_to_nwb/rivera_and_shukla_2025/rivera_and_shukla_2025_convert_all_sessions.py
@@ -129,6 +129,8 @@ def get_session_to_nwb_kwargs_per_session(
         for subject_pair_folder in condition_folder_path.iterdir():
             subject_id1, subject_id2 = subject_pair_folder.name.split("-")
             for session_folder_path in subject_pair_folder.iterdir():
+                if session_folder_path.name == "07-17-2023":
+                    continue  # Skip this session bc it has duplicate data from another session (07-15-2023)
                 sub1_session_to_nwb_kwargs = dict(
                     session_folder_path=session_folder_path,
                     subject_id=subject_id1,

--- a/src/jadhav_lab_to_nwb/rivera_and_shukla_2025/rivera_and_shukla_2025_convert_all_sessions.py
+++ b/src/jadhav_lab_to_nwb/rivera_and_shukla_2025/rivera_and_shukla_2025_convert_all_sessions.py
@@ -4,8 +4,9 @@ from concurrent.futures import ProcessPoolExecutor, as_completed
 from pprint import pformat
 import traceback
 from tqdm import tqdm
+import warnings
 
-from .rivera_and_shukla_2025_convert_session import session_to_nwb
+from jadhav_lab_to_nwb.rivera_and_shukla_2025.rivera_and_shukla_2025_convert_session import session_to_nwb
 
 
 def dataset_to_nwb(
@@ -31,26 +32,40 @@ def dataset_to_nwb(
     data_dir_path = Path(data_dir_path)
     session_to_nwb_kwargs_per_session = get_session_to_nwb_kwargs_per_session(
         data_dir_path=data_dir_path,
+        output_dir_path=Path(output_dir_path),
+        verbose=verbose,
     )
+
+    exception_folder_path = Path(output_dir_path) / "exceptions"
+    exception_folder_path.mkdir(parents=True, exist_ok=True)
+    warnings_folder_path = Path(output_dir_path) / "warnings"
+    warnings_folder_path.mkdir(parents=True, exist_ok=True)
 
     futures = []
     with ProcessPoolExecutor(max_workers=max_workers) as executor:
         for session_to_nwb_kwargs in session_to_nwb_kwargs_per_session:
             session_to_nwb_kwargs["output_dir_path"] = output_dir_path
             session_to_nwb_kwargs["verbose"] = verbose
-            exception_file_path = data_dir_path / f"ERROR_<nwbfile_name>.txt"  # Add error file path here
+            subject_id = session_to_nwb_kwargs["subject_id"]
+            session_id = session_to_nwb_kwargs["session_folder_path"].name
+            nwbfile_name = f"sub-{subject_id}_ses-{session_id}.nwb"
+            exception_file_path = exception_folder_path / f"ERROR_{nwbfile_name}.txt"
+            warnings_file_path = warnings_folder_path / f"WARNINGS_{nwbfile_name}.txt"
             futures.append(
                 executor.submit(
                     safe_session_to_nwb,
                     session_to_nwb_kwargs=session_to_nwb_kwargs,
                     exception_file_path=exception_file_path,
+                    warnings_file_path=warnings_file_path,
                 )
             )
         for _ in tqdm(as_completed(futures), total=len(futures)):
             pass
 
 
-def safe_session_to_nwb(*, session_to_nwb_kwargs: dict, exception_file_path: str | Path):
+def safe_session_to_nwb(
+    *, session_to_nwb_kwargs: dict, exception_file_path: str | Path, warnings_file_path: str | Path
+):
     """Convert a session to NWB while handling any errors by recording error messages to the exception_file_path.
 
     Parameters
@@ -59,19 +74,37 @@ def safe_session_to_nwb(*, session_to_nwb_kwargs: dict, exception_file_path: str
         The arguments for session_to_nwb.
     exception_file_path : Path
         The path to the file where the exception messages will be saved.
+    warnings_file_path : Path
+        The path to the file where warnings will be saved.
     """
     exception_file_path = Path(exception_file_path)
-    try:
-        session_to_nwb(**session_to_nwb_kwargs)
-    except Exception as e:
-        with open(exception_file_path, mode="w") as f:
+    warnings_file_path = Path(warnings_file_path)
+
+    # Capture warnings
+    with warnings.catch_warnings(record=True) as warning_list:
+        warnings.simplefilter("always")
+
+        try:
+            session_to_nwb(**session_to_nwb_kwargs)
+        except Exception as e:
+            with open(exception_file_path, mode="w") as f:
+                f.write(f"session_to_nwb_kwargs: \n {pformat(session_to_nwb_kwargs)}\n\n")
+                f.write(traceback.format_exc())
+
+    # Write warnings to file if any occurred
+    if warning_list:
+        with open(warnings_file_path, mode="w") as f:
             f.write(f"session_to_nwb_kwargs: \n {pformat(session_to_nwb_kwargs)}\n\n")
-            f.write(traceback.format_exc())
+            for warning in warning_list:
+                f.write(f"{warning.category.__name__}: {warning.message}\n")
+                f.write(f"File: {warning.filename}, Line: {warning.lineno}\n\n")
 
 
 def get_session_to_nwb_kwargs_per_session(
     *,
-    data_dir_path: str | Path,
+    data_dir_path: Path,
+    output_dir_path: Path,
+    verbose: bool = False,
 ):
     """Get the kwargs for session_to_nwb for each session in the dataset.
 
@@ -79,25 +112,50 @@ def get_session_to_nwb_kwargs_per_session(
     ----------
     data_dir_path : str | Path
         The path to the directory containing the raw data.
+    output_dir_path : str | Path
+        The path to the directory where the NWB files will be saved.
+    verbose : bool, optional
+        Whether to print verbose output, by default False
 
     Returns
     -------
     list[dict[str, Any]]
         A list of dictionaries containing the kwargs for session_to_nwb for each session.
     """
-    #####
-    # # Implement this function to return the kwargs for session_to_nwb for each session
-    # This can be a specific list with hard-coded sessions, a path expansion or any conversion specific logic that you might need
-    #####
-    raise NotImplementedError
+    experimental_conditions = ["100%", "50%", "Opaque"]
+    session_to_nwb_kwargs_per_session = []
+    for condition in experimental_conditions:
+        condition_folder_path = data_dir_path / "CohortAS1" / "Social W" / condition
+        for subject_pair_folder in condition_folder_path.iterdir():
+            subject_id1, subject_id2 = subject_pair_folder.name.split("-")
+            for session_folder_path in subject_pair_folder.iterdir():
+                sub1_session_to_nwb_kwargs = dict(
+                    session_folder_path=session_folder_path,
+                    subject_id=subject_id1,
+                    output_dir_path=output_dir_path,
+                    experimental_condition=condition,
+                    stub_test=False,
+                    verbose=verbose,
+                )
+                sub2_session_to_nwb_kwargs = dict(
+                    session_folder_path=session_folder_path,
+                    subject_id=subject_id2,
+                    output_dir_path=output_dir_path,
+                    experimental_condition=condition,
+                    stub_test=False,
+                    verbose=verbose,
+                )
+                session_to_nwb_kwargs_per_session.append(sub1_session_to_nwb_kwargs)
+                session_to_nwb_kwargs_per_session.append(sub2_session_to_nwb_kwargs)
+    return session_to_nwb_kwargs_per_session
 
 
 if __name__ == "__main__":
 
     # Parameters for conversion
-    data_dir_path = Path("/Directory/With/Raw/Formats/")
-    output_dir_path = Path("~/conversion_nwb/")
-    max_workers = 1
+    data_dir_path = Path("/Volumes/T7/CatalystNeuro/Jadhav/CoopLearnProject")
+    output_dir_path = Path("/Volumes/T7/CatalystNeuro/Spyglass/raw")
+    max_workers = 4
     verbose = False
 
     dataset_to_nwb(

--- a/src/jadhav_lab_to_nwb/rivera_and_shukla_2025/rivera_and_shukla_2025_convert_session.py
+++ b/src/jadhav_lab_to_nwb/rivera_and_shukla_2025/rivera_and_shukla_2025_convert_session.py
@@ -115,66 +115,129 @@ def main():
     stub_test = False
     verbose = True
 
-    # Example Session 100% reward
-    session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN1-XFN3" / "07-20-2023"
-    session_to_nwb(
-        session_folder_path=session_folder_path,
-        subject_id="XFN1",
-        output_dir_path=output_dir_path,
-        experimental_condition="100%",
-        stub_test=stub_test,
-        verbose=verbose,
-    )
+    # # Example Session 100% reward
+    # session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN1-XFN3" / "07-20-2023"
+    # session_to_nwb(
+    #     session_folder_path=session_folder_path,
+    #     subject_id="XFN1",
+    #     output_dir_path=output_dir_path,
+    #     experimental_condition="100%",
+    #     stub_test=stub_test,
+    #     verbose=verbose,
+    # )
 
-    session_to_nwb(
-        session_folder_path=session_folder_path,
-        subject_id="XFN3",
-        output_dir_path=output_dir_path,
-        experimental_condition="100%",
-        stub_test=stub_test,
-        verbose=verbose,
-    )
+    # session_to_nwb(
+    #     session_folder_path=session_folder_path,
+    #     subject_id="XFN3",
+    #     output_dir_path=output_dir_path,
+    #     experimental_condition="100%",
+    #     stub_test=stub_test,
+    #     verbose=verbose,
+    # )
 
-    # Example Session 50% reward
-    session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "50%" / "XFN1-XFN3" / "08-08-2023"
-    session_to_nwb(
-        session_folder_path=session_folder_path,
-        subject_id="XFN1",
-        output_dir_path=output_dir_path,
-        experimental_condition="50%",
-        stub_test=stub_test,
-        verbose=verbose,
-    )
-    session_to_nwb(
-        session_folder_path=session_folder_path,
-        subject_id="XFN3",
-        output_dir_path=output_dir_path,
-        experimental_condition="50%",
-        stub_test=stub_test,
-        verbose=verbose,
-    )
+    # # Example Session 50% reward
+    # session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "50%" / "XFN1-XFN3" / "08-08-2023"
+    # session_to_nwb(
+    #     session_folder_path=session_folder_path,
+    #     subject_id="XFN1",
+    #     output_dir_path=output_dir_path,
+    #     experimental_condition="50%",
+    #     stub_test=stub_test,
+    #     verbose=verbose,
+    # )
+    # session_to_nwb(
+    #     session_folder_path=session_folder_path,
+    #     subject_id="XFN3",
+    #     output_dir_path=output_dir_path,
+    #     experimental_condition="50%",
+    #     stub_test=stub_test,
+    #     verbose=verbose,
+    # )
 
-    # Example Session Opaque
-    session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "Opaque" / "XFN1-XFN3" / "08-16-2023"
-    session_to_nwb(
-        session_folder_path=session_folder_path,
-        subject_id="XFN1",
-        output_dir_path=output_dir_path,
-        experimental_condition="Opaque",
-        stub_test=stub_test,
-        verbose=verbose,
-    )
-    session_to_nwb(
-        session_folder_path=session_folder_path,
-        subject_id="XFN3",
-        output_dir_path=output_dir_path,
-        experimental_condition="Opaque",
-        stub_test=stub_test,
-        verbose=verbose,
-    )
+    # # Example Session Opaque
+    # session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "Opaque" / "XFN1-XFN3" / "08-16-2023"
+    # session_to_nwb(
+    #     session_folder_path=session_folder_path,
+    #     subject_id="XFN1",
+    #     output_dir_path=output_dir_path,
+    #     experimental_condition="Opaque",
+    #     stub_test=stub_test,
+    #     verbose=verbose,
+    # )
+    # session_to_nwb(
+    #     session_folder_path=session_folder_path,
+    #     subject_id="XFN3",
+    #     output_dir_path=output_dir_path,
+    #     experimental_condition="Opaque",
+    #     stub_test=stub_test,
+    #     verbose=verbose,
+    # )
 
-    # Example Session WT
-    session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN2-XFN4" / "07-19-2023"
+    # # Example Session WT
+    # session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN2-XFN4" / "07-19-2023"
+    # session_to_nwb(
+    #     session_folder_path=session_folder_path,
+    #     subject_id="XFN2",
+    #     output_dir_path=output_dir_path,
+    #     experimental_condition="100%",
+    #     stub_test=stub_test,
+    #     verbose=verbose,
+    # )
+    # session_to_nwb(
+    #     session_folder_path=session_folder_path,
+    #     subject_id="XFN4",
+    #     output_dir_path=output_dir_path,
+    #     experimental_condition="100%",
+    #     stub_test=stub_test,
+    #     verbose=verbose,
+    # )
+
+    # # Example Session Single Epoch
+    # session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN2-XFN4" / "07-15-2023"
+    # session_to_nwb(
+    #     session_folder_path=session_folder_path,
+    #     subject_id="XFN2",
+    #     output_dir_path=output_dir_path,
+    #     experimental_condition="100%",
+    #     stub_test=stub_test,
+    #     verbose=verbose,
+    # )
+    # session_to_nwb(
+    #     session_folder_path=session_folder_path,
+    #     subject_id="XFN4",
+    #     output_dir_path=output_dir_path,
+    #     experimental_condition="100%",
+    #     stub_test=stub_test,
+    #     verbose=verbose,
+    # )
+
+    # # Example Session DIO-only
+    # session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN1-XFN3" / "07-17-2023"
+    # session_to_nwb(
+    #     session_folder_path=session_folder_path,
+    #     subject_id="XFN1",
+    #     output_dir_path=output_dir_path,
+    #     experimental_condition="100%",
+    #     stub_test=stub_test,
+    #     verbose=verbose,
+    # )
+    # session_to_nwb(
+    #     session_folder_path=session_folder_path,
+    #     subject_id="XFN3",
+    #     output_dir_path=output_dir_path,
+    #     experimental_condition="100%",
+    #     stub_test=stub_test,
+    #     verbose=verbose,
+    # )
+
+    #     - Some of the sessions (ex. CoopLearnProject/CohortAS1/Social W/100%/XFN2-XFN4/07-14-2023) has a different number of timestamps for video and DLC
+    # - Some of the sessions (ex. CoopLearnProject/CohortAS1/Social W/50%/XFN1-XFN3/08-16-2023) are missing DLC epochs
+    # - Some of the sessions (ex. CoopLearnProject/CohortAS1/Social W/100%/XFN1-XFN3/07-15-2023) have incomplete epochs
+    # - Some of the sessions (ex. CoopLearnProject/CohortAS1/Social W/100%/XFN1-XFN3/07-27-2023) have corrupted hdf5 files --> investigate
+    # - Some of the sessions (ex. CoopLearnProject/CohortAS1/Social W/50%/XFN1-XFN3/08-07-2023) have multiple videos/epoch --> need to investigate
+
+    # Example Session Multiple Videos for a single epoch
+    session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN2-XFN4" / "07-24-2023"
     session_to_nwb(
         session_folder_path=session_folder_path,
         subject_id="XFN2",
@@ -186,44 +249,6 @@ def main():
     session_to_nwb(
         session_folder_path=session_folder_path,
         subject_id="XFN4",
-        output_dir_path=output_dir_path,
-        experimental_condition="100%",
-        stub_test=stub_test,
-        verbose=verbose,
-    )
-
-    # Example Session Single Epoch
-    session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN2-XFN4" / "07-15-2023"
-    session_to_nwb(
-        session_folder_path=session_folder_path,
-        subject_id="XFN2",
-        output_dir_path=output_dir_path,
-        experimental_condition="100%",
-        stub_test=stub_test,
-        verbose=verbose,
-    )
-    session_to_nwb(
-        session_folder_path=session_folder_path,
-        subject_id="XFN4",
-        output_dir_path=output_dir_path,
-        experimental_condition="100%",
-        stub_test=stub_test,
-        verbose=verbose,
-    )
-
-    # Example Session DIO-only
-    session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN1-XFN3" / "07-17-2023"
-    session_to_nwb(
-        session_folder_path=session_folder_path,
-        subject_id="XFN1",
-        output_dir_path=output_dir_path,
-        experimental_condition="100%",
-        stub_test=stub_test,
-        verbose=verbose,
-    )
-    session_to_nwb(
-        session_folder_path=session_folder_path,
-        subject_id="XFN3",
         output_dir_path=output_dir_path,
         experimental_condition="100%",
         stub_test=stub_test,

--- a/src/jadhav_lab_to_nwb/rivera_and_shukla_2025/rivera_and_shukla_2025_convert_session.py
+++ b/src/jadhav_lab_to_nwb/rivera_and_shukla_2025/rivera_and_shukla_2025_convert_session.py
@@ -83,7 +83,7 @@ def session_to_nwb(
     metadata = converter.get_metadata()
 
     # Add datetime to conversion
-    session_start_time = datetime(2023, 7, 20, 0, 0, 0)  # TODO: Update this to the actual session start time
+    session_start_time = datetime.strptime(session_id, "%m-%d-%Y")
     est = ZoneInfo("US/Eastern")
     session_start_time = session_start_time.replace(tzinfo=est)
     metadata["NWBFile"]["session_start_time"] = session_start_time

--- a/src/jadhav_lab_to_nwb/rivera_and_shukla_2025/rivera_and_shukla_2025_convert_session.py
+++ b/src/jadhav_lab_to_nwb/rivera_and_shukla_2025/rivera_and_shukla_2025_convert_session.py
@@ -105,60 +105,77 @@ def main():
     stub_test = False
     verbose = True
 
-    # Example Session 100% reward
-    session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN1-XFN3" / "07-20-2023"
-    session_to_nwb(
-        session_folder_path=session_folder_path,
-        subject_id="XFN1",
-        output_dir_path=output_dir_path,
-        stub_test=stub_test,
-        verbose=verbose,
-    )
+    # # Example Session 100% reward
+    # session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN1-XFN3" / "07-20-2023"
+    # session_to_nwb(
+    #     session_folder_path=session_folder_path,
+    #     subject_id="XFN1",
+    #     output_dir_path=output_dir_path,
+    #     stub_test=stub_test,
+    #     verbose=verbose,
+    # )
 
-    session_to_nwb(
-        session_folder_path=session_folder_path,
-        subject_id="XFN3",
-        output_dir_path=output_dir_path,
-        stub_test=stub_test,
-        verbose=verbose,
-    )
+    # session_to_nwb(
+    #     session_folder_path=session_folder_path,
+    #     subject_id="XFN3",
+    #     output_dir_path=output_dir_path,
+    #     stub_test=stub_test,
+    #     verbose=verbose,
+    # )
 
-    # Example Session 50% reward
-    session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "50%" / "XFN1-XFN3" / "08-08-2023"
-    session_to_nwb(
-        session_folder_path=session_folder_path,
-        subject_id="XFN1",
-        output_dir_path=output_dir_path,
-        stub_test=stub_test,
-        verbose=verbose,
-    )
-    session_to_nwb(
-        session_folder_path=session_folder_path,
-        subject_id="XFN3",
-        output_dir_path=output_dir_path,
-        stub_test=stub_test,
-        verbose=verbose,
-    )
+    # # Example Session 50% reward
+    # session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "50%" / "XFN1-XFN3" / "08-08-2023"
+    # session_to_nwb(
+    #     session_folder_path=session_folder_path,
+    #     subject_id="XFN1",
+    #     output_dir_path=output_dir_path,
+    #     stub_test=stub_test,
+    #     verbose=verbose,
+    # )
+    # session_to_nwb(
+    #     session_folder_path=session_folder_path,
+    #     subject_id="XFN3",
+    #     output_dir_path=output_dir_path,
+    #     stub_test=stub_test,
+    #     verbose=verbose,
+    # )
 
-    # Example Session Opaque
-    session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "Opaque" / "XFN1-XFN3" / "08-16-2023"
-    session_to_nwb(
-        session_folder_path=session_folder_path,
-        subject_id="XFN1",
-        output_dir_path=output_dir_path,
-        stub_test=stub_test,
-        verbose=verbose,
-    )
-    session_to_nwb(
-        session_folder_path=session_folder_path,
-        subject_id="XFN3",
-        output_dir_path=output_dir_path,
-        stub_test=stub_test,
-        verbose=verbose,
-    )
+    # # Example Session Opaque
+    # session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "Opaque" / "XFN1-XFN3" / "08-16-2023"
+    # session_to_nwb(
+    #     session_folder_path=session_folder_path,
+    #     subject_id="XFN1",
+    #     output_dir_path=output_dir_path,
+    #     stub_test=stub_test,
+    #     verbose=verbose,
+    # )
+    # session_to_nwb(
+    #     session_folder_path=session_folder_path,
+    #     subject_id="XFN3",
+    #     output_dir_path=output_dir_path,
+    #     stub_test=stub_test,
+    #     verbose=verbose,
+    # )
 
-    # Example Session WT
-    session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN2-XFN4" / "07-19-2023"
+    # # Example Session WT
+    # session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN2-XFN4" / "07-19-2023"
+    # session_to_nwb(
+    #     session_folder_path=session_folder_path,
+    #     subject_id="XFN2",
+    #     output_dir_path=output_dir_path,
+    #     stub_test=stub_test,
+    #     verbose=verbose,
+    # )
+    # session_to_nwb(
+    #     session_folder_path=session_folder_path,
+    #     subject_id="XFN4",
+    #     output_dir_path=output_dir_path,
+    #     stub_test=stub_test,
+    #     verbose=verbose,
+    # )
+
+    # Example Session Single Epoch
+    session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN2-XFN4" / "07-15-2023"
     session_to_nwb(
         session_folder_path=session_folder_path,
         subject_id="XFN2",

--- a/src/jadhav_lab_to_nwb/rivera_and_shukla_2025/rivera_and_shukla_2025_convert_session.py
+++ b/src/jadhav_lab_to_nwb/rivera_and_shukla_2025/rivera_and_shukla_2025_convert_session.py
@@ -139,199 +139,218 @@ def main():
     stub_test = False
     verbose = True
 
-    # # Example Session 100% reward
-    # session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN1-XFN3" / "07-20-2023"
-    # session_to_nwb(
-    #     session_folder_path=session_folder_path,
-    #     subject_id="XFN1",
-    #     output_dir_path=output_dir_path,
-    #     experimental_condition="100%",
-    #     stub_test=stub_test,
-    #     verbose=verbose,
-    # )
+    # Example Session 100% reward
+    session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN1-XFN3" / "07-20-2023"
+    session_to_nwb(
+        session_folder_path=session_folder_path,
+        subject_id="XFN1",
+        output_dir_path=output_dir_path,
+        experimental_condition="100%",
+        stub_test=stub_test,
+        verbose=verbose,
+    )
 
-    # session_to_nwb(
-    #     session_folder_path=session_folder_path,
-    #     subject_id="XFN3",
-    #     output_dir_path=output_dir_path,
-    #     experimental_condition="100%",
-    #     stub_test=stub_test,
-    #     verbose=verbose,
-    # )
+    session_to_nwb(
+        session_folder_path=session_folder_path,
+        subject_id="XFN3",
+        output_dir_path=output_dir_path,
+        experimental_condition="100%",
+        stub_test=stub_test,
+        verbose=verbose,
+    )
 
-    # # Example Session 50% reward
-    # session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "50%" / "XFN1-XFN3" / "08-08-2023"
-    # session_to_nwb(
-    #     session_folder_path=session_folder_path,
-    #     subject_id="XFN1",
-    #     output_dir_path=output_dir_path,
-    #     experimental_condition="50%",
-    #     stub_test=stub_test,
-    #     verbose=verbose,
-    # )
-    # session_to_nwb(
-    #     session_folder_path=session_folder_path,
-    #     subject_id="XFN3",
-    #     output_dir_path=output_dir_path,
-    #     experimental_condition="50%",
-    #     stub_test=stub_test,
-    #     verbose=verbose,
-    # )
+    # Example Session 50% reward
+    session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "50%" / "XFN1-XFN3" / "08-08-2023"
+    session_to_nwb(
+        session_folder_path=session_folder_path,
+        subject_id="XFN1",
+        output_dir_path=output_dir_path,
+        experimental_condition="50%",
+        stub_test=stub_test,
+        verbose=verbose,
+    )
+    session_to_nwb(
+        session_folder_path=session_folder_path,
+        subject_id="XFN3",
+        output_dir_path=output_dir_path,
+        experimental_condition="50%",
+        stub_test=stub_test,
+        verbose=verbose,
+    )
 
-    # # Example Session Opaque
-    # session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "Opaque" / "XFN1-XFN3" / "08-16-2023"
-    # session_to_nwb(
-    #     session_folder_path=session_folder_path,
-    #     subject_id="XFN1",
-    #     output_dir_path=output_dir_path,
-    #     experimental_condition="Opaque",
-    #     stub_test=stub_test,
-    #     verbose=verbose,
-    # )
-    # session_to_nwb(
-    #     session_folder_path=session_folder_path,
-    #     subject_id="XFN3",
-    #     output_dir_path=output_dir_path,
-    #     experimental_condition="Opaque",
-    #     stub_test=stub_test,
-    #     verbose=verbose,
-    # )
+    # Example Session Opaque
+    session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "Opaque" / "XFN1-XFN3" / "08-16-2023"
+    session_to_nwb(
+        session_folder_path=session_folder_path,
+        subject_id="XFN1",
+        output_dir_path=output_dir_path,
+        experimental_condition="Opaque",
+        stub_test=stub_test,
+        verbose=verbose,
+    )
+    session_to_nwb(
+        session_folder_path=session_folder_path,
+        subject_id="XFN3",
+        output_dir_path=output_dir_path,
+        experimental_condition="Opaque",
+        stub_test=stub_test,
+        verbose=verbose,
+    )
 
-    # # Example Session WT
-    # session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN2-XFN4" / "07-19-2023"
-    # session_to_nwb(
-    #     session_folder_path=session_folder_path,
-    #     subject_id="XFN2",
-    #     output_dir_path=output_dir_path,
-    #     experimental_condition="100%",
-    #     stub_test=stub_test,
-    #     verbose=verbose,
-    # )
-    # session_to_nwb(
-    #     session_folder_path=session_folder_path,
-    #     subject_id="XFN4",
-    #     output_dir_path=output_dir_path,
-    #     experimental_condition="100%",
-    #     stub_test=stub_test,
-    #     verbose=verbose,
-    # )
+    # Example Session WT
+    session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN2-XFN4" / "07-19-2023"
+    session_to_nwb(
+        session_folder_path=session_folder_path,
+        subject_id="XFN2",
+        output_dir_path=output_dir_path,
+        experimental_condition="100%",
+        stub_test=stub_test,
+        verbose=verbose,
+    )
+    session_to_nwb(
+        session_folder_path=session_folder_path,
+        subject_id="XFN4",
+        output_dir_path=output_dir_path,
+        experimental_condition="100%",
+        stub_test=stub_test,
+        verbose=verbose,
+    )
 
-    # # Example Session Single Epoch
-    # session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN2-XFN4" / "07-15-2023"
-    # session_to_nwb(
-    #     session_folder_path=session_folder_path,
-    #     subject_id="XFN2",
-    #     output_dir_path=output_dir_path,
-    #     experimental_condition="100%",
-    #     stub_test=stub_test,
-    #     verbose=verbose,
-    # )
-    # session_to_nwb(
-    #     session_folder_path=session_folder_path,
-    #     subject_id="XFN4",
-    #     output_dir_path=output_dir_path,
-    #     experimental_condition="100%",
-    #     stub_test=stub_test,
-    #     verbose=verbose,
-    # )
+    # Example Session Single Epoch
+    session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN2-XFN4" / "07-15-2023"
+    session_to_nwb(
+        session_folder_path=session_folder_path,
+        subject_id="XFN2",
+        output_dir_path=output_dir_path,
+        experimental_condition="100%",
+        stub_test=stub_test,
+        verbose=verbose,
+    )
+    session_to_nwb(
+        session_folder_path=session_folder_path,
+        subject_id="XFN4",
+        output_dir_path=output_dir_path,
+        experimental_condition="100%",
+        stub_test=stub_test,
+        verbose=verbose,
+    )
 
-    # # Example Session DIO-only
-    # session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "50%" / "XFN1-XFN3" / "08-03-2023"
-    # session_to_nwb(
-    #     session_folder_path=session_folder_path,
-    #     subject_id="XFN1",
-    #     output_dir_path=output_dir_path,
-    #     experimental_condition="50%",
-    #     stub_test=stub_test,
-    #     verbose=verbose,
-    # )
-    # session_to_nwb(
-    #     session_folder_path=session_folder_path,
-    #     subject_id="XFN3",
-    #     output_dir_path=output_dir_path,
-    #     experimental_condition="50%",
-    #     stub_test=stub_test,
-    #     verbose=verbose,
-    # )
+    # Example Session DIO-only
+    session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "50%" / "XFN1-XFN3" / "08-03-2023"
+    session_to_nwb(
+        session_folder_path=session_folder_path,
+        subject_id="XFN1",
+        output_dir_path=output_dir_path,
+        experimental_condition="50%",
+        stub_test=stub_test,
+        verbose=verbose,
+    )
+    session_to_nwb(
+        session_folder_path=session_folder_path,
+        subject_id="XFN3",
+        output_dir_path=output_dir_path,
+        experimental_condition="50%",
+        stub_test=stub_test,
+        verbose=verbose,
+    )
 
-    # # Example Session Multiple Videos for a single epoch
-    # session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN2-XFN4" / "07-24-2023"
-    # session_to_nwb(
-    #     session_folder_path=session_folder_path,
-    #     subject_id="XFN2",
-    #     output_dir_path=output_dir_path,
-    #     experimental_condition="100%",
-    #     stub_test=stub_test,
-    #     verbose=verbose,
-    # )
-    # session_to_nwb(
-    #     session_folder_path=session_folder_path,
-    #     subject_id="XFN4",
-    #     output_dir_path=output_dir_path,
-    #     experimental_condition="100%",
-    #     stub_test=stub_test,
-    #     verbose=verbose,
-    # )
+    # Example Session Multiple Videos for a single epoch
+    session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN2-XFN4" / "07-24-2023"
+    session_to_nwb(
+        session_folder_path=session_folder_path,
+        subject_id="XFN2",
+        output_dir_path=output_dir_path,
+        experimental_condition="100%",
+        stub_test=stub_test,
+        verbose=verbose,
+    )
+    session_to_nwb(
+        session_folder_path=session_folder_path,
+        subject_id="XFN4",
+        output_dir_path=output_dir_path,
+        experimental_condition="100%",
+        stub_test=stub_test,
+        verbose=verbose,
+    )
 
-    # # Example Session with corrupted hdf5 files
-    # session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN1-XFN3" / "07-27-2023"
-    # session_to_nwb(
-    #     session_folder_path=session_folder_path,
-    #     subject_id="XFN1",
-    #     output_dir_path=output_dir_path,
-    #     experimental_condition="100%",
-    #     stub_test=stub_test,
-    #     verbose=verbose,
-    # )
-    # session_to_nwb(
-    #     session_folder_path=session_folder_path,
-    #     subject_id="XFN3",
-    #     output_dir_path=output_dir_path,
-    #     experimental_condition="100%",
-    #     stub_test=stub_test,
-    #     verbose=verbose,
-    # )
+    # Example Session with corrupted hdf5 files
+    session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN1-XFN3" / "07-27-2023"
+    session_to_nwb(
+        session_folder_path=session_folder_path,
+        subject_id="XFN1",
+        output_dir_path=output_dir_path,
+        experimental_condition="100%",
+        stub_test=stub_test,
+        verbose=verbose,
+    )
+    session_to_nwb(
+        session_folder_path=session_folder_path,
+        subject_id="XFN3",
+        output_dir_path=output_dir_path,
+        experimental_condition="100%",
+        stub_test=stub_test,
+        verbose=verbose,
+    )
 
-    # # Example Session with incomplete epochs and mismatched timestamps
-    # session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN1-XFN3" / "07-15-2023"
-    # session_to_nwb(
-    #     session_folder_path=session_folder_path,
-    #     subject_id="XFN1",
-    #     output_dir_path=output_dir_path,
-    #     experimental_condition="100%",
-    #     stub_test=stub_test,
-    #     verbose=verbose,
-    # )
-    # session_to_nwb(
-    #     session_folder_path=session_folder_path,
-    #     subject_id="XFN3",
-    #     output_dir_path=output_dir_path,
-    #     experimental_condition="100%",
-    #     stub_test=stub_test,
-    #     verbose=verbose,
-    # )
+    # Example Session with incomplete epochs and mismatched timestamps
+    session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN1-XFN3" / "07-15-2023"
+    session_to_nwb(
+        session_folder_path=session_folder_path,
+        subject_id="XFN1",
+        output_dir_path=output_dir_path,
+        experimental_condition="100%",
+        stub_test=stub_test,
+        verbose=verbose,
+    )
+    session_to_nwb(
+        session_folder_path=session_folder_path,
+        subject_id="XFN3",
+        output_dir_path=output_dir_path,
+        experimental_condition="100%",
+        stub_test=stub_test,
+        verbose=verbose,
+    )
 
-    # # Example Session with missing DLC epochs
-    # session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "50%" / "XFN1-XFN3" / "08-16-2023"
-    # session_to_nwb(
-    #     session_folder_path=session_folder_path,
-    #     subject_id="XFN1",
-    #     output_dir_path=output_dir_path,
-    #     experimental_condition="50%",
-    #     stub_test=stub_test,
-    #     verbose=verbose,
-    # )
-    # session_to_nwb(
-    #     session_folder_path=session_folder_path,
-    #     subject_id="XFN3",
-    #     output_dir_path=output_dir_path,
-    #     experimental_condition="50%",
-    #     stub_test=stub_test,
-    #     verbose=verbose,
-    # )
+    # Example Session with missing DLC epochs
+    session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "50%" / "XFN1-XFN3" / "08-16-2023"
+    session_to_nwb(
+        session_folder_path=session_folder_path,
+        subject_id="XFN1",
+        output_dir_path=output_dir_path,
+        experimental_condition="50%",
+        stub_test=stub_test,
+        verbose=verbose,
+    )
+    session_to_nwb(
+        session_folder_path=session_folder_path,
+        subject_id="XFN3",
+        output_dir_path=output_dir_path,
+        experimental_condition="50%",
+        stub_test=stub_test,
+        verbose=verbose,
+    )
 
     # Example Session with missing DLC segment
     session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "50%" / "XFN2-XFN4" / "08-03-2023"
+    session_to_nwb(
+        session_folder_path=session_folder_path,
+        subject_id="XFN2",
+        output_dir_path=output_dir_path,
+        experimental_condition="50%",
+        stub_test=stub_test,
+        verbose=verbose,
+    )
+    session_to_nwb(
+        session_folder_path=session_folder_path,
+        subject_id="XFN4",
+        output_dir_path=output_dir_path,
+        experimental_condition="50%",
+        stub_test=stub_test,
+        verbose=verbose,
+    )
+
+    # Example Session with ~~~ in the stateScriptLog
+    session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "50%" / "XFN2-XFN4" / "09-21-2023"
     session_to_nwb(
         session_folder_path=session_folder_path,
         subject_id="XFN2",

--- a/src/jadhav_lab_to_nwb/rivera_and_shukla_2025/rivera_and_shukla_2025_convert_session.py
+++ b/src/jadhav_lab_to_nwb/rivera_and_shukla_2025/rivera_and_shukla_2025_convert_session.py
@@ -92,8 +92,7 @@ def session_to_nwb(
     converter.run_conversion(metadata=metadata, nwbfile_path=nwbfile_path, conversion_options=conversion_options)
 
 
-if __name__ == "__main__":
-
+def main():
     # Parameters for conversion
     data_dir_path = Path("/Volumes/T7/CatalystNeuro/Jadhav/CoopLearnProject")
     output_dir_path = Path("/Volumes/T7/CatalystNeuro/Spyglass/raw")
@@ -129,3 +128,37 @@ if __name__ == "__main__":
         output_dir_path=output_dir_path,
         stub_test=stub_test,
     )
+
+    # Example Session Opaque
+    session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "Opaque" / "XFN1-XFN3" / "08-16-2023"
+    session_to_nwb(
+        session_folder_path=session_folder_path,
+        subject_id="XFN1",
+        output_dir_path=output_dir_path,
+        stub_test=stub_test,
+    )
+    session_to_nwb(
+        session_folder_path=session_folder_path,
+        subject_id="XFN3",
+        output_dir_path=output_dir_path,
+        stub_test=stub_test,
+    )
+
+    # Example Session WT
+    session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN2-XFN4" / "07-14-2023"
+    session_to_nwb(
+        session_folder_path=session_folder_path,
+        subject_id="XFN2",
+        output_dir_path=output_dir_path,
+        stub_test=stub_test,
+    )
+    session_to_nwb(
+        session_folder_path=session_folder_path,
+        subject_id="XFN4",
+        output_dir_path=output_dir_path,
+        stub_test=stub_test,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/jadhav_lab_to_nwb/rivera_and_shukla_2025/rivera_and_shukla_2025_convert_session.py
+++ b/src/jadhav_lab_to_nwb/rivera_and_shukla_2025/rivera_and_shukla_2025_convert_session.py
@@ -16,6 +16,7 @@ def session_to_nwb(
     subject_id: str,
     output_dir_path: DirectoryPath,
     stub_test: bool = False,
+    verbose: bool = False,
 ):
     session_folder_path = Path(session_folder_path)
     session_id = session_folder_path.name
@@ -46,6 +47,7 @@ def session_to_nwb(
         for file_path in dlc_folder_path.glob(r"*.h5")
         if not (file_path.name.startswith("._")) and "resnet50" in file_path.name
     ]
+    file_paths = natsorted(file_paths)
     subject_1, subject_2 = session_folder_path.parent.name.split("-")
     source_data.update(
         dict(
@@ -71,7 +73,7 @@ def session_to_nwb(
     source_data.update(dict(Epoch=dict(video_timestamps_file_paths=video_timestamps_file_paths)))
     conversion_options.update(dict(Epoch=dict()))
 
-    converter = RiveraAndShukla2025NWBConverter(source_data=source_data)
+    converter = RiveraAndShukla2025NWBConverter(source_data=source_data, verbose=verbose)
     metadata = converter.get_metadata()
 
     # Add datetime to conversion
@@ -92,12 +94,16 @@ def session_to_nwb(
     # Run conversion
     converter.run_conversion(metadata=metadata, nwbfile_path=nwbfile_path, conversion_options=conversion_options)
 
+    if verbose:
+        print(f"Successfully converted session {session_id} for subject {subject_id} to NWB format.")
+
 
 def main():
     # Parameters for conversion
     data_dir_path = Path("/Volumes/T7/CatalystNeuro/Jadhav/CoopLearnProject")
     output_dir_path = Path("/Volumes/T7/CatalystNeuro/Spyglass/raw")
     stub_test = False
+    verbose = True
 
     # Example Session 100% reward
     session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN1-XFN3" / "07-20-2023"
@@ -106,6 +112,7 @@ def main():
         subject_id="XFN1",
         output_dir_path=output_dir_path,
         stub_test=stub_test,
+        verbose=verbose,
     )
 
     session_to_nwb(
@@ -113,6 +120,7 @@ def main():
         subject_id="XFN3",
         output_dir_path=output_dir_path,
         stub_test=stub_test,
+        verbose=verbose,
     )
 
     # Example Session 50% reward
@@ -122,12 +130,14 @@ def main():
         subject_id="XFN1",
         output_dir_path=output_dir_path,
         stub_test=stub_test,
+        verbose=verbose,
     )
     session_to_nwb(
         session_folder_path=session_folder_path,
         subject_id="XFN3",
         output_dir_path=output_dir_path,
         stub_test=stub_test,
+        verbose=verbose,
     )
 
     # Example Session Opaque
@@ -137,27 +147,31 @@ def main():
         subject_id="XFN1",
         output_dir_path=output_dir_path,
         stub_test=stub_test,
+        verbose=verbose,
     )
     session_to_nwb(
         session_folder_path=session_folder_path,
         subject_id="XFN3",
         output_dir_path=output_dir_path,
         stub_test=stub_test,
+        verbose=verbose,
     )
 
     # Example Session WT
-    session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN2-XFN4" / "07-14-2023"
+    session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN2-XFN4" / "07-19-2023"
     session_to_nwb(
         session_folder_path=session_folder_path,
         subject_id="XFN2",
         output_dir_path=output_dir_path,
         stub_test=stub_test,
+        verbose=verbose,
     )
     session_to_nwb(
         session_folder_path=session_folder_path,
         subject_id="XFN4",
         output_dir_path=output_dir_path,
         stub_test=stub_test,
+        verbose=verbose,
     )
 
 

--- a/src/jadhav_lab_to_nwb/rivera_and_shukla_2025/rivera_and_shukla_2025_convert_session.py
+++ b/src/jadhav_lab_to_nwb/rivera_and_shukla_2025/rivera_and_shukla_2025_convert_session.py
@@ -36,39 +36,51 @@ def session_to_nwb(
     # Add Video
     file_paths = natsorted(list(dio_folder_path.glob("*.h264")))
     video_timestamps_file_paths = natsorted(list(dio_folder_path.glob("*.videoTimeStamps")))
+    epoch_name_to_file_paths, epoch_name_to_timestamps_file_paths = {}, {}
     for file_path, video_timestamps_file_path in zip(file_paths, video_timestamps_file_paths):
         file_epoch_name = rivera_and_shukla_2025_get_epoch_name(name=file_path.name)
         timestamps_epoch_name = rivera_and_shukla_2025_get_epoch_name(name=video_timestamps_file_path.name)
         assert file_epoch_name == timestamps_epoch_name, "Video files were not sorted correctly."
+        if file_epoch_name not in epoch_name_to_file_paths:
+            epoch_name_to_file_paths[file_epoch_name] = []
+        epoch_name_to_file_paths[file_epoch_name].append(file_path)
+        if timestamps_epoch_name not in epoch_name_to_timestamps_file_paths:
+            epoch_name_to_timestamps_file_paths[timestamps_epoch_name] = []
+        epoch_name_to_timestamps_file_paths[timestamps_epoch_name].append(video_timestamps_file_path)
+    file_paths = []
+    video_timestamps_file_paths = []
+    for epoch_name in natsorted(epoch_name_to_file_paths.keys()):
+        file_paths.append(natsorted(epoch_name_to_file_paths[epoch_name]))
+        video_timestamps_file_paths.append(natsorted(epoch_name_to_timestamps_file_paths[epoch_name]))
     source_data.update(dict(Video=dict(file_paths=file_paths, video_timestamps_file_paths=video_timestamps_file_paths)))
     conversion_options.update(dict(Video=dict()))
 
-    # Add DLC
-    file_paths = [
-        file_path
-        for file_path in dlc_folder_path.glob(r"*.h5")
-        if not (file_path.name.startswith("._")) and "resnet50" in file_path.name
-    ]
-    if len(file_paths) > 0:
-        file_paths = natsorted(file_paths)
-        subject_1, subject_2 = session_folder_path.parent.name.split("-")
-        source_data.update(
-            dict(
-                DeepLabCut1=dict(
-                    file_paths=file_paths,
-                    subject_id=subject_1,
-                ),
-                DeepLabCut2=dict(
-                    file_paths=file_paths,
-                    subject_id=subject_2,
-                ),
-            )
-        )
-        conversion_options.update(dict(DeepLabCut1=dict()))
-        conversion_options.update(dict(DeepLabCut2=dict()))
-    else:
-        if verbose:
-            print(f"No DLC data found for session {session_id} and subject {subject_id}. Skipping DLC conversion.")
+    # # Add DLC
+    # file_paths = [
+    #     file_path
+    #     for file_path in dlc_folder_path.glob(r"*.h5")
+    #     if not (file_path.name.startswith("._")) and "resnet50" in file_path.name
+    # ]
+    # if len(file_paths) > 0:
+    #     file_paths = natsorted(file_paths)
+    #     subject_1, subject_2 = session_folder_path.parent.name.split("-")
+    #     source_data.update(
+    #         dict(
+    #             DeepLabCut1=dict(
+    #                 file_paths=file_paths,
+    #                 subject_id=subject_1,
+    #             ),
+    #             DeepLabCut2=dict(
+    #                 file_paths=file_paths,
+    #                 subject_id=subject_2,
+    #             ),
+    #         )
+    #     )
+    #     conversion_options.update(dict(DeepLabCut1=dict()))
+    #     conversion_options.update(dict(DeepLabCut2=dict()))
+    # else:
+    #     if verbose:
+    #         print(f"No DLC data found for session {session_id} and subject {subject_id}. Skipping DLC conversion.")
 
     # Add Behavior
     file_paths = natsorted(list(dio_folder_path.glob("*.stateScriptLog")))

--- a/src/jadhav_lab_to_nwb/rivera_and_shukla_2025/rivera_and_shukla_2025_convert_session.py
+++ b/src/jadhav_lab_to_nwb/rivera_and_shukla_2025/rivera_and_shukla_2025_convert_session.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from datetime import datetime
 from zoneinfo import ZoneInfo
 from pydantic import FilePath, DirectoryPath
+from natsort import natsorted
 
 from neuroconv.utils import load_dict_from_file, dict_deep_update
 
@@ -30,8 +31,8 @@ def session_to_nwb(
     conversion_options = dict()
 
     # Add Video
-    file_paths = sorted(list(dio_folder_path.glob("*.h264")))
-    video_timestamps_file_paths = sorted(list(dio_folder_path.glob("*.videoTimeStamps")))
+    file_paths = natsorted(list(dio_folder_path.glob("*.h264")))
+    video_timestamps_file_paths = natsorted(list(dio_folder_path.glob("*.videoTimeStamps")))
     for file_path, video_timestamps_file_path in zip(file_paths, video_timestamps_file_paths):
         file_epoch_name = rivera_and_shukla_2025_get_epoch_name(name=file_path.name)
         timestamps_epoch_name = rivera_and_shukla_2025_get_epoch_name(name=video_timestamps_file_path.name)
@@ -62,7 +63,7 @@ def session_to_nwb(
     conversion_options.update(dict(DeepLabCut2=dict()))
 
     # Add Behavior
-    file_paths = sorted(list(dio_folder_path.glob("*.stateScriptLog")))
+    file_paths = natsorted(list(dio_folder_path.glob("*.stateScriptLog")))
     source_data.update(dict(Behavior=dict(file_paths=file_paths)))
     conversion_options.update(dict(Behavior=dict()))
 

--- a/src/jadhav_lab_to_nwb/rivera_and_shukla_2025/rivera_and_shukla_2025_convert_session.py
+++ b/src/jadhav_lab_to_nwb/rivera_and_shukla_2025/rivera_and_shukla_2025_convert_session.py
@@ -292,13 +292,32 @@ def main():
     #     verbose=verbose,
     # )
 
-    # Example Session with incomplete epochs and mismatched timestamps
-    session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN1-XFN3" / "07-15-2023"
+    # # Example Session with incomplete epochs and mismatched timestamps
+    # session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN1-XFN3" / "07-15-2023"
+    # session_to_nwb(
+    #     session_folder_path=session_folder_path,
+    #     subject_id="XFN1",
+    #     output_dir_path=output_dir_path,
+    #     experimental_condition="100%",
+    #     stub_test=stub_test,
+    #     verbose=verbose,
+    # )
+    # session_to_nwb(
+    #     session_folder_path=session_folder_path,
+    #     subject_id="XFN3",
+    #     output_dir_path=output_dir_path,
+    #     experimental_condition="100%",
+    #     stub_test=stub_test,
+    #     verbose=verbose,
+    # )
+
+    # Example Session with missing DLC epochs
+    session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "50%" / "XFN1-XFN3" / "08-16-2023"
     session_to_nwb(
         session_folder_path=session_folder_path,
         subject_id="XFN1",
         output_dir_path=output_dir_path,
-        experimental_condition="100%",
+        experimental_condition="50%",
         stub_test=stub_test,
         verbose=verbose,
     )
@@ -306,7 +325,7 @@ def main():
         session_folder_path=session_folder_path,
         subject_id="XFN3",
         output_dir_path=output_dir_path,
-        experimental_condition="100%",
+        experimental_condition="50%",
         stub_test=stub_test,
         verbose=verbose,
     )

--- a/src/jadhav_lab_to_nwb/rivera_and_shukla_2025/rivera_and_shukla_2025_convert_session.py
+++ b/src/jadhav_lab_to_nwb/rivera_and_shukla_2025/rivera_and_shukla_2025_convert_session.py
@@ -254,21 +254,21 @@ def main():
         verbose=verbose,
     )
 
-    # Example Session Multiple Videos for a single epoch
-    session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN2-XFN4" / "07-24-2023"
+    # Example Session Multiple Videos (segments) for a single epoch
+    session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "50%" / "XFN1-XFN3" / "08-07-2023"
     session_to_nwb(
         session_folder_path=session_folder_path,
-        subject_id="XFN2",
+        subject_id="XFN1",
         output_dir_path=output_dir_path,
-        experimental_condition="100%",
+        experimental_condition="50%",
         stub_test=stub_test,
         verbose=verbose,
     )
     session_to_nwb(
         session_folder_path=session_folder_path,
-        subject_id="XFN4",
+        subject_id="XFN3",
         output_dir_path=output_dir_path,
-        experimental_condition="100%",
+        experimental_condition="50%",
         stub_test=stub_test,
         verbose=verbose,
     )

--- a/src/jadhav_lab_to_nwb/rivera_and_shukla_2025/rivera_and_shukla_2025_convert_session.py
+++ b/src/jadhav_lab_to_nwb/rivera_and_shukla_2025/rivera_and_shukla_2025_convert_session.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from zoneinfo import ZoneInfo
 from pydantic import FilePath, DirectoryPath
 from natsort import natsorted
+from typing import Literal
 
 from neuroconv.utils import load_dict_from_file, dict_deep_update
 
@@ -15,6 +16,7 @@ def session_to_nwb(
     session_folder_path: DirectoryPath,
     subject_id: str,
     output_dir_path: DirectoryPath,
+    experimental_condition: Literal["100%", "50%", "Opaque"],
     stub_test: bool = False,
     verbose: bool = False,
 ):
@@ -95,6 +97,10 @@ def session_to_nwb(
     # Add genotype
     metadata["Subject"]["genotype"] = metadata["SubjectMaps"]["subject_id_to_genotype"][subject_id]
 
+    # Add session description
+    session_description = metadata["SessionMaps"]["condition_to_session_description"][experimental_condition]
+    metadata["NWBFile"]["session_description"] = session_description
+
     # Run conversion
     converter.run_conversion(metadata=metadata, nwbfile_path=nwbfile_path, conversion_options=conversion_options)
 
@@ -115,6 +121,7 @@ def main():
         session_folder_path=session_folder_path,
         subject_id="XFN1",
         output_dir_path=output_dir_path,
+        experimental_condition="100%",
         stub_test=stub_test,
         verbose=verbose,
     )
@@ -123,6 +130,7 @@ def main():
         session_folder_path=session_folder_path,
         subject_id="XFN3",
         output_dir_path=output_dir_path,
+        experimental_condition="100%",
         stub_test=stub_test,
         verbose=verbose,
     )
@@ -133,6 +141,7 @@ def main():
         session_folder_path=session_folder_path,
         subject_id="XFN1",
         output_dir_path=output_dir_path,
+        experimental_condition="50%",
         stub_test=stub_test,
         verbose=verbose,
     )
@@ -140,6 +149,7 @@ def main():
         session_folder_path=session_folder_path,
         subject_id="XFN3",
         output_dir_path=output_dir_path,
+        experimental_condition="50%",
         stub_test=stub_test,
         verbose=verbose,
     )
@@ -150,6 +160,7 @@ def main():
         session_folder_path=session_folder_path,
         subject_id="XFN1",
         output_dir_path=output_dir_path,
+        experimental_condition="Opaque",
         stub_test=stub_test,
         verbose=verbose,
     )
@@ -157,6 +168,7 @@ def main():
         session_folder_path=session_folder_path,
         subject_id="XFN3",
         output_dir_path=output_dir_path,
+        experimental_condition="Opaque",
         stub_test=stub_test,
         verbose=verbose,
     )
@@ -167,6 +179,7 @@ def main():
         session_folder_path=session_folder_path,
         subject_id="XFN2",
         output_dir_path=output_dir_path,
+        experimental_condition="100%",
         stub_test=stub_test,
         verbose=verbose,
     )
@@ -174,6 +187,7 @@ def main():
         session_folder_path=session_folder_path,
         subject_id="XFN4",
         output_dir_path=output_dir_path,
+        experimental_condition="100%",
         stub_test=stub_test,
         verbose=verbose,
     )
@@ -184,6 +198,7 @@ def main():
         session_folder_path=session_folder_path,
         subject_id="XFN2",
         output_dir_path=output_dir_path,
+        experimental_condition="100%",
         stub_test=stub_test,
         verbose=verbose,
     )
@@ -191,6 +206,7 @@ def main():
         session_folder_path=session_folder_path,
         subject_id="XFN4",
         output_dir_path=output_dir_path,
+        experimental_condition="100%",
         stub_test=stub_test,
         verbose=verbose,
     )
@@ -201,6 +217,7 @@ def main():
         session_folder_path=session_folder_path,
         subject_id="XFN1",
         output_dir_path=output_dir_path,
+        experimental_condition="100%",
         stub_test=stub_test,
         verbose=verbose,
     )
@@ -208,6 +225,7 @@ def main():
         session_folder_path=session_folder_path,
         subject_id="XFN3",
         output_dir_path=output_dir_path,
+        experimental_condition="100%",
         stub_test=stub_test,
         verbose=verbose,
     )

--- a/src/jadhav_lab_to_nwb/rivera_and_shukla_2025/rivera_and_shukla_2025_convert_session.py
+++ b/src/jadhav_lab_to_nwb/rivera_and_shukla_2025/rivera_and_shukla_2025_convert_session.py
@@ -5,6 +5,7 @@ from zoneinfo import ZoneInfo
 from pydantic import FilePath, DirectoryPath
 from natsort import natsorted
 from typing import Literal
+from h5py import is_hdf5
 
 from neuroconv.utils import load_dict_from_file, dict_deep_update
 
@@ -59,7 +60,7 @@ def session_to_nwb(
     file_paths = [
         file_path
         for file_path in dlc_folder_path.glob(r"*.h5")
-        if not (file_path.name.startswith("._")) and "resnet50" in file_path.name
+        if not (file_path.name.startswith("._")) and "resnet50" in file_path.name and is_hdf5(file_path)
     ]
     if len(file_paths) > 0:
         file_paths = natsorted(file_paths)
@@ -136,126 +137,120 @@ def main():
     stub_test = False
     verbose = True
 
-    # # Example Session 100% reward
-    # session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN1-XFN3" / "07-20-2023"
-    # session_to_nwb(
-    #     session_folder_path=session_folder_path,
-    #     subject_id="XFN1",
-    #     output_dir_path=output_dir_path,
-    #     experimental_condition="100%",
-    #     stub_test=stub_test,
-    #     verbose=verbose,
-    # )
+    # Example Session 100% reward
+    session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN1-XFN3" / "07-20-2023"
+    session_to_nwb(
+        session_folder_path=session_folder_path,
+        subject_id="XFN1",
+        output_dir_path=output_dir_path,
+        experimental_condition="100%",
+        stub_test=stub_test,
+        verbose=verbose,
+    )
 
-    # session_to_nwb(
-    #     session_folder_path=session_folder_path,
-    #     subject_id="XFN3",
-    #     output_dir_path=output_dir_path,
-    #     experimental_condition="100%",
-    #     stub_test=stub_test,
-    #     verbose=verbose,
-    # )
+    session_to_nwb(
+        session_folder_path=session_folder_path,
+        subject_id="XFN3",
+        output_dir_path=output_dir_path,
+        experimental_condition="100%",
+        stub_test=stub_test,
+        verbose=verbose,
+    )
 
-    # # Example Session 50% reward
-    # session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "50%" / "XFN1-XFN3" / "08-08-2023"
-    # session_to_nwb(
-    #     session_folder_path=session_folder_path,
-    #     subject_id="XFN1",
-    #     output_dir_path=output_dir_path,
-    #     experimental_condition="50%",
-    #     stub_test=stub_test,
-    #     verbose=verbose,
-    # )
-    # session_to_nwb(
-    #     session_folder_path=session_folder_path,
-    #     subject_id="XFN3",
-    #     output_dir_path=output_dir_path,
-    #     experimental_condition="50%",
-    #     stub_test=stub_test,
-    #     verbose=verbose,
-    # )
+    # Example Session 50% reward
+    session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "50%" / "XFN1-XFN3" / "08-08-2023"
+    session_to_nwb(
+        session_folder_path=session_folder_path,
+        subject_id="XFN1",
+        output_dir_path=output_dir_path,
+        experimental_condition="50%",
+        stub_test=stub_test,
+        verbose=verbose,
+    )
+    session_to_nwb(
+        session_folder_path=session_folder_path,
+        subject_id="XFN3",
+        output_dir_path=output_dir_path,
+        experimental_condition="50%",
+        stub_test=stub_test,
+        verbose=verbose,
+    )
 
-    # # Example Session Opaque
-    # session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "Opaque" / "XFN1-XFN3" / "08-16-2023"
-    # session_to_nwb(
-    #     session_folder_path=session_folder_path,
-    #     subject_id="XFN1",
-    #     output_dir_path=output_dir_path,
-    #     experimental_condition="Opaque",
-    #     stub_test=stub_test,
-    #     verbose=verbose,
-    # )
-    # session_to_nwb(
-    #     session_folder_path=session_folder_path,
-    #     subject_id="XFN3",
-    #     output_dir_path=output_dir_path,
-    #     experimental_condition="Opaque",
-    #     stub_test=stub_test,
-    #     verbose=verbose,
-    # )
+    # Example Session Opaque
+    session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "Opaque" / "XFN1-XFN3" / "08-16-2023"
+    session_to_nwb(
+        session_folder_path=session_folder_path,
+        subject_id="XFN1",
+        output_dir_path=output_dir_path,
+        experimental_condition="Opaque",
+        stub_test=stub_test,
+        verbose=verbose,
+    )
+    session_to_nwb(
+        session_folder_path=session_folder_path,
+        subject_id="XFN3",
+        output_dir_path=output_dir_path,
+        experimental_condition="Opaque",
+        stub_test=stub_test,
+        verbose=verbose,
+    )
 
-    # # Example Session WT
-    # session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN2-XFN4" / "07-19-2023"
-    # session_to_nwb(
-    #     session_folder_path=session_folder_path,
-    #     subject_id="XFN2",
-    #     output_dir_path=output_dir_path,
-    #     experimental_condition="100%",
-    #     stub_test=stub_test,
-    #     verbose=verbose,
-    # )
-    # session_to_nwb(
-    #     session_folder_path=session_folder_path,
-    #     subject_id="XFN4",
-    #     output_dir_path=output_dir_path,
-    #     experimental_condition="100%",
-    #     stub_test=stub_test,
-    #     verbose=verbose,
-    # )
+    # Example Session WT
+    session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN2-XFN4" / "07-19-2023"
+    session_to_nwb(
+        session_folder_path=session_folder_path,
+        subject_id="XFN2",
+        output_dir_path=output_dir_path,
+        experimental_condition="100%",
+        stub_test=stub_test,
+        verbose=verbose,
+    )
+    session_to_nwb(
+        session_folder_path=session_folder_path,
+        subject_id="XFN4",
+        output_dir_path=output_dir_path,
+        experimental_condition="100%",
+        stub_test=stub_test,
+        verbose=verbose,
+    )
 
-    # # Example Session Single Epoch
-    # session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN2-XFN4" / "07-15-2023"
-    # session_to_nwb(
-    #     session_folder_path=session_folder_path,
-    #     subject_id="XFN2",
-    #     output_dir_path=output_dir_path,
-    #     experimental_condition="100%",
-    #     stub_test=stub_test,
-    #     verbose=verbose,
-    # )
-    # session_to_nwb(
-    #     session_folder_path=session_folder_path,
-    #     subject_id="XFN4",
-    #     output_dir_path=output_dir_path,
-    #     experimental_condition="100%",
-    #     stub_test=stub_test,
-    #     verbose=verbose,
-    # )
+    # Example Session Single Epoch
+    session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN2-XFN4" / "07-15-2023"
+    session_to_nwb(
+        session_folder_path=session_folder_path,
+        subject_id="XFN2",
+        output_dir_path=output_dir_path,
+        experimental_condition="100%",
+        stub_test=stub_test,
+        verbose=verbose,
+    )
+    session_to_nwb(
+        session_folder_path=session_folder_path,
+        subject_id="XFN4",
+        output_dir_path=output_dir_path,
+        experimental_condition="100%",
+        stub_test=stub_test,
+        verbose=verbose,
+    )
 
-    # # Example Session DIO-only
-    # session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN1-XFN3" / "07-17-2023"
-    # session_to_nwb(
-    #     session_folder_path=session_folder_path,
-    #     subject_id="XFN1",
-    #     output_dir_path=output_dir_path,
-    #     experimental_condition="100%",
-    #     stub_test=stub_test,
-    #     verbose=verbose,
-    # )
-    # session_to_nwb(
-    #     session_folder_path=session_folder_path,
-    #     subject_id="XFN3",
-    #     output_dir_path=output_dir_path,
-    #     experimental_condition="100%",
-    #     stub_test=stub_test,
-    #     verbose=verbose,
-    # )
-
-    #     - Some of the sessions (ex. CoopLearnProject/CohortAS1/Social W/100%/XFN2-XFN4/07-14-2023) has a different number of timestamps for video and DLC
-    # - Some of the sessions (ex. CoopLearnProject/CohortAS1/Social W/50%/XFN1-XFN3/08-16-2023) are missing DLC epochs
-    # - Some of the sessions (ex. CoopLearnProject/CohortAS1/Social W/100%/XFN1-XFN3/07-15-2023) have incomplete epochs
-    # - Some of the sessions (ex. CoopLearnProject/CohortAS1/Social W/100%/XFN1-XFN3/07-27-2023) have corrupted hdf5 files --> investigate
-    # - Some of the sessions (ex. CoopLearnProject/CohortAS1/Social W/50%/XFN1-XFN3/08-07-2023) have multiple videos/epoch --> need to investigate
+    # Example Session DIO-only
+    session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN1-XFN3" / "07-17-2023"
+    session_to_nwb(
+        session_folder_path=session_folder_path,
+        subject_id="XFN1",
+        output_dir_path=output_dir_path,
+        experimental_condition="100%",
+        stub_test=stub_test,
+        verbose=verbose,
+    )
+    session_to_nwb(
+        session_folder_path=session_folder_path,
+        subject_id="XFN3",
+        output_dir_path=output_dir_path,
+        experimental_condition="100%",
+        stub_test=stub_test,
+        verbose=verbose,
+    )
 
     # Example Session Multiple Videos for a single epoch
     session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN2-XFN4" / "07-24-2023"
@@ -270,6 +265,25 @@ def main():
     session_to_nwb(
         session_folder_path=session_folder_path,
         subject_id="XFN4",
+        output_dir_path=output_dir_path,
+        experimental_condition="100%",
+        stub_test=stub_test,
+        verbose=verbose,
+    )
+
+    # Example Session with corrupted hdf5 files
+    session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN1-XFN3" / "07-27-2023"
+    session_to_nwb(
+        session_folder_path=session_folder_path,
+        subject_id="XFN1",
+        output_dir_path=output_dir_path,
+        experimental_condition="100%",
+        stub_test=stub_test,
+        verbose=verbose,
+    )
+    session_to_nwb(
+        session_folder_path=session_folder_path,
+        subject_id="XFN3",
         output_dir_path=output_dir_path,
         experimental_condition="100%",
         stub_test=stub_test,

--- a/src/jadhav_lab_to_nwb/rivera_and_shukla_2025/rivera_and_shukla_2025_convert_session.py
+++ b/src/jadhav_lab_to_nwb/rivera_and_shukla_2025/rivera_and_shukla_2025_convert_session.py
@@ -139,177 +139,177 @@ def main():
     stub_test = False
     verbose = True
 
-    # # Example Session 100% reward
-    # session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN1-XFN3" / "07-20-2023"
-    # session_to_nwb(
-    #     session_folder_path=session_folder_path,
-    #     subject_id="XFN1",
-    #     output_dir_path=output_dir_path,
-    #     experimental_condition="100%",
-    #     stub_test=stub_test,
-    #     verbose=verbose,
-    # )
+    # Example Session 100% reward
+    session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN1-XFN3" / "07-20-2023"
+    session_to_nwb(
+        session_folder_path=session_folder_path,
+        subject_id="XFN1",
+        output_dir_path=output_dir_path,
+        experimental_condition="100%",
+        stub_test=stub_test,
+        verbose=verbose,
+    )
 
-    # session_to_nwb(
-    #     session_folder_path=session_folder_path,
-    #     subject_id="XFN3",
-    #     output_dir_path=output_dir_path,
-    #     experimental_condition="100%",
-    #     stub_test=stub_test,
-    #     verbose=verbose,
-    # )
+    session_to_nwb(
+        session_folder_path=session_folder_path,
+        subject_id="XFN3",
+        output_dir_path=output_dir_path,
+        experimental_condition="100%",
+        stub_test=stub_test,
+        verbose=verbose,
+    )
 
-    # # Example Session 50% reward
-    # session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "50%" / "XFN1-XFN3" / "08-08-2023"
-    # session_to_nwb(
-    #     session_folder_path=session_folder_path,
-    #     subject_id="XFN1",
-    #     output_dir_path=output_dir_path,
-    #     experimental_condition="50%",
-    #     stub_test=stub_test,
-    #     verbose=verbose,
-    # )
-    # session_to_nwb(
-    #     session_folder_path=session_folder_path,
-    #     subject_id="XFN3",
-    #     output_dir_path=output_dir_path,
-    #     experimental_condition="50%",
-    #     stub_test=stub_test,
-    #     verbose=verbose,
-    # )
+    # Example Session 50% reward
+    session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "50%" / "XFN1-XFN3" / "08-08-2023"
+    session_to_nwb(
+        session_folder_path=session_folder_path,
+        subject_id="XFN1",
+        output_dir_path=output_dir_path,
+        experimental_condition="50%",
+        stub_test=stub_test,
+        verbose=verbose,
+    )
+    session_to_nwb(
+        session_folder_path=session_folder_path,
+        subject_id="XFN3",
+        output_dir_path=output_dir_path,
+        experimental_condition="50%",
+        stub_test=stub_test,
+        verbose=verbose,
+    )
 
-    # # Example Session Opaque
-    # session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "Opaque" / "XFN1-XFN3" / "08-16-2023"
-    # session_to_nwb(
-    #     session_folder_path=session_folder_path,
-    #     subject_id="XFN1",
-    #     output_dir_path=output_dir_path,
-    #     experimental_condition="Opaque",
-    #     stub_test=stub_test,
-    #     verbose=verbose,
-    # )
-    # session_to_nwb(
-    #     session_folder_path=session_folder_path,
-    #     subject_id="XFN3",
-    #     output_dir_path=output_dir_path,
-    #     experimental_condition="Opaque",
-    #     stub_test=stub_test,
-    #     verbose=verbose,
-    # )
+    # Example Session Opaque
+    session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "Opaque" / "XFN1-XFN3" / "08-16-2023"
+    session_to_nwb(
+        session_folder_path=session_folder_path,
+        subject_id="XFN1",
+        output_dir_path=output_dir_path,
+        experimental_condition="Opaque",
+        stub_test=stub_test,
+        verbose=verbose,
+    )
+    session_to_nwb(
+        session_folder_path=session_folder_path,
+        subject_id="XFN3",
+        output_dir_path=output_dir_path,
+        experimental_condition="Opaque",
+        stub_test=stub_test,
+        verbose=verbose,
+    )
 
-    # # Example Session WT
-    # session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN2-XFN4" / "07-19-2023"
-    # session_to_nwb(
-    #     session_folder_path=session_folder_path,
-    #     subject_id="XFN2",
-    #     output_dir_path=output_dir_path,
-    #     experimental_condition="100%",
-    #     stub_test=stub_test,
-    #     verbose=verbose,
-    # )
-    # session_to_nwb(
-    #     session_folder_path=session_folder_path,
-    #     subject_id="XFN4",
-    #     output_dir_path=output_dir_path,
-    #     experimental_condition="100%",
-    #     stub_test=stub_test,
-    #     verbose=verbose,
-    # )
+    # Example Session WT
+    session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN2-XFN4" / "07-19-2023"
+    session_to_nwb(
+        session_folder_path=session_folder_path,
+        subject_id="XFN2",
+        output_dir_path=output_dir_path,
+        experimental_condition="100%",
+        stub_test=stub_test,
+        verbose=verbose,
+    )
+    session_to_nwb(
+        session_folder_path=session_folder_path,
+        subject_id="XFN4",
+        output_dir_path=output_dir_path,
+        experimental_condition="100%",
+        stub_test=stub_test,
+        verbose=verbose,
+    )
 
-    # # Example Session Single Epoch
-    # session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN2-XFN4" / "07-15-2023"
-    # session_to_nwb(
-    #     session_folder_path=session_folder_path,
-    #     subject_id="XFN2",
-    #     output_dir_path=output_dir_path,
-    #     experimental_condition="100%",
-    #     stub_test=stub_test,
-    #     verbose=verbose,
-    # )
-    # session_to_nwb(
-    #     session_folder_path=session_folder_path,
-    #     subject_id="XFN4",
-    #     output_dir_path=output_dir_path,
-    #     experimental_condition="100%",
-    #     stub_test=stub_test,
-    #     verbose=verbose,
-    # )
+    # Example Session Single Epoch
+    session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN2-XFN4" / "07-15-2023"
+    session_to_nwb(
+        session_folder_path=session_folder_path,
+        subject_id="XFN2",
+        output_dir_path=output_dir_path,
+        experimental_condition="100%",
+        stub_test=stub_test,
+        verbose=verbose,
+    )
+    session_to_nwb(
+        session_folder_path=session_folder_path,
+        subject_id="XFN4",
+        output_dir_path=output_dir_path,
+        experimental_condition="100%",
+        stub_test=stub_test,
+        verbose=verbose,
+    )
 
-    # # Example Session DIO-only
-    # session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN1-XFN3" / "07-17-2023"
-    # session_to_nwb(
-    #     session_folder_path=session_folder_path,
-    #     subject_id="XFN1",
-    #     output_dir_path=output_dir_path,
-    #     experimental_condition="100%",
-    #     stub_test=stub_test,
-    #     verbose=verbose,
-    # )
-    # session_to_nwb(
-    #     session_folder_path=session_folder_path,
-    #     subject_id="XFN3",
-    #     output_dir_path=output_dir_path,
-    #     experimental_condition="100%",
-    #     stub_test=stub_test,
-    #     verbose=verbose,
-    # )
+    # Example Session DIO-only
+    session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "50%" / "XFN1-XFN3" / "08-03-2023"
+    session_to_nwb(
+        session_folder_path=session_folder_path,
+        subject_id="XFN1",
+        output_dir_path=output_dir_path,
+        experimental_condition="50%",
+        stub_test=stub_test,
+        verbose=verbose,
+    )
+    session_to_nwb(
+        session_folder_path=session_folder_path,
+        subject_id="XFN3",
+        output_dir_path=output_dir_path,
+        experimental_condition="50%",
+        stub_test=stub_test,
+        verbose=verbose,
+    )
 
-    # # Example Session Multiple Videos for a single epoch
-    # session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN2-XFN4" / "07-24-2023"
-    # session_to_nwb(
-    #     session_folder_path=session_folder_path,
-    #     subject_id="XFN2",
-    #     output_dir_path=output_dir_path,
-    #     experimental_condition="100%",
-    #     stub_test=stub_test,
-    #     verbose=verbose,
-    # )
-    # session_to_nwb(
-    #     session_folder_path=session_folder_path,
-    #     subject_id="XFN4",
-    #     output_dir_path=output_dir_path,
-    #     experimental_condition="100%",
-    #     stub_test=stub_test,
-    #     verbose=verbose,
-    # )
+    # Example Session Multiple Videos for a single epoch
+    session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN2-XFN4" / "07-24-2023"
+    session_to_nwb(
+        session_folder_path=session_folder_path,
+        subject_id="XFN2",
+        output_dir_path=output_dir_path,
+        experimental_condition="100%",
+        stub_test=stub_test,
+        verbose=verbose,
+    )
+    session_to_nwb(
+        session_folder_path=session_folder_path,
+        subject_id="XFN4",
+        output_dir_path=output_dir_path,
+        experimental_condition="100%",
+        stub_test=stub_test,
+        verbose=verbose,
+    )
 
-    # # Example Session with corrupted hdf5 files
-    # session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN1-XFN3" / "07-27-2023"
-    # session_to_nwb(
-    #     session_folder_path=session_folder_path,
-    #     subject_id="XFN1",
-    #     output_dir_path=output_dir_path,
-    #     experimental_condition="100%",
-    #     stub_test=stub_test,
-    #     verbose=verbose,
-    # )
-    # session_to_nwb(
-    #     session_folder_path=session_folder_path,
-    #     subject_id="XFN3",
-    #     output_dir_path=output_dir_path,
-    #     experimental_condition="100%",
-    #     stub_test=stub_test,
-    #     verbose=verbose,
-    # )
+    # Example Session with corrupted hdf5 files
+    session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN1-XFN3" / "07-27-2023"
+    session_to_nwb(
+        session_folder_path=session_folder_path,
+        subject_id="XFN1",
+        output_dir_path=output_dir_path,
+        experimental_condition="100%",
+        stub_test=stub_test,
+        verbose=verbose,
+    )
+    session_to_nwb(
+        session_folder_path=session_folder_path,
+        subject_id="XFN3",
+        output_dir_path=output_dir_path,
+        experimental_condition="100%",
+        stub_test=stub_test,
+        verbose=verbose,
+    )
 
-    # # Example Session with incomplete epochs and mismatched timestamps
-    # session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN1-XFN3" / "07-15-2023"
-    # session_to_nwb(
-    #     session_folder_path=session_folder_path,
-    #     subject_id="XFN1",
-    #     output_dir_path=output_dir_path,
-    #     experimental_condition="100%",
-    #     stub_test=stub_test,
-    #     verbose=verbose,
-    # )
-    # session_to_nwb(
-    #     session_folder_path=session_folder_path,
-    #     subject_id="XFN3",
-    #     output_dir_path=output_dir_path,
-    #     experimental_condition="100%",
-    #     stub_test=stub_test,
-    #     verbose=verbose,
-    # )
+    # Example Session with incomplete epochs and mismatched timestamps
+    session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN1-XFN3" / "07-15-2023"
+    session_to_nwb(
+        session_folder_path=session_folder_path,
+        subject_id="XFN1",
+        output_dir_path=output_dir_path,
+        experimental_condition="100%",
+        stub_test=stub_test,
+        verbose=verbose,
+    )
+    session_to_nwb(
+        session_folder_path=session_folder_path,
+        subject_id="XFN3",
+        output_dir_path=output_dir_path,
+        experimental_condition="100%",
+        stub_test=stub_test,
+        verbose=verbose,
+    )
 
     # Example Session with missing DLC epochs
     session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "50%" / "XFN1-XFN3" / "08-16-2023"

--- a/src/jadhav_lab_to_nwb/rivera_and_shukla_2025/rivera_and_shukla_2025_convert_session.py
+++ b/src/jadhav_lab_to_nwb/rivera_and_shukla_2025/rivera_and_shukla_2025_convert_session.py
@@ -47,22 +47,26 @@ def session_to_nwb(
         for file_path in dlc_folder_path.glob(r"*.h5")
         if not (file_path.name.startswith("._")) and "resnet50" in file_path.name
     ]
-    file_paths = natsorted(file_paths)
-    subject_1, subject_2 = session_folder_path.parent.name.split("-")
-    source_data.update(
-        dict(
-            DeepLabCut1=dict(
-                file_paths=file_paths,
-                subject_id=subject_1,
-            ),
-            DeepLabCut2=dict(
-                file_paths=file_paths,
-                subject_id=subject_2,
-            ),
+    if len(file_paths) > 0:
+        file_paths = natsorted(file_paths)
+        subject_1, subject_2 = session_folder_path.parent.name.split("-")
+        source_data.update(
+            dict(
+                DeepLabCut1=dict(
+                    file_paths=file_paths,
+                    subject_id=subject_1,
+                ),
+                DeepLabCut2=dict(
+                    file_paths=file_paths,
+                    subject_id=subject_2,
+                ),
+            )
         )
-    )
-    conversion_options.update(dict(DeepLabCut1=dict()))
-    conversion_options.update(dict(DeepLabCut2=dict()))
+        conversion_options.update(dict(DeepLabCut1=dict()))
+        conversion_options.update(dict(DeepLabCut2=dict()))
+    else:
+        if verbose:
+            print(f"No DLC data found for session {session_id} and subject {subject_id}. Skipping DLC conversion.")
 
     # Add Behavior
     file_paths = natsorted(list(dio_folder_path.glob("*.stateScriptLog")))
@@ -105,74 +109,74 @@ def main():
     stub_test = False
     verbose = True
 
-    # # Example Session 100% reward
-    # session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN1-XFN3" / "07-20-2023"
-    # session_to_nwb(
-    #     session_folder_path=session_folder_path,
-    #     subject_id="XFN1",
-    #     output_dir_path=output_dir_path,
-    #     stub_test=stub_test,
-    #     verbose=verbose,
-    # )
+    # Example Session 100% reward
+    session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN1-XFN3" / "07-20-2023"
+    session_to_nwb(
+        session_folder_path=session_folder_path,
+        subject_id="XFN1",
+        output_dir_path=output_dir_path,
+        stub_test=stub_test,
+        verbose=verbose,
+    )
 
-    # session_to_nwb(
-    #     session_folder_path=session_folder_path,
-    #     subject_id="XFN3",
-    #     output_dir_path=output_dir_path,
-    #     stub_test=stub_test,
-    #     verbose=verbose,
-    # )
+    session_to_nwb(
+        session_folder_path=session_folder_path,
+        subject_id="XFN3",
+        output_dir_path=output_dir_path,
+        stub_test=stub_test,
+        verbose=verbose,
+    )
 
-    # # Example Session 50% reward
-    # session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "50%" / "XFN1-XFN3" / "08-08-2023"
-    # session_to_nwb(
-    #     session_folder_path=session_folder_path,
-    #     subject_id="XFN1",
-    #     output_dir_path=output_dir_path,
-    #     stub_test=stub_test,
-    #     verbose=verbose,
-    # )
-    # session_to_nwb(
-    #     session_folder_path=session_folder_path,
-    #     subject_id="XFN3",
-    #     output_dir_path=output_dir_path,
-    #     stub_test=stub_test,
-    #     verbose=verbose,
-    # )
+    # Example Session 50% reward
+    session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "50%" / "XFN1-XFN3" / "08-08-2023"
+    session_to_nwb(
+        session_folder_path=session_folder_path,
+        subject_id="XFN1",
+        output_dir_path=output_dir_path,
+        stub_test=stub_test,
+        verbose=verbose,
+    )
+    session_to_nwb(
+        session_folder_path=session_folder_path,
+        subject_id="XFN3",
+        output_dir_path=output_dir_path,
+        stub_test=stub_test,
+        verbose=verbose,
+    )
 
-    # # Example Session Opaque
-    # session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "Opaque" / "XFN1-XFN3" / "08-16-2023"
-    # session_to_nwb(
-    #     session_folder_path=session_folder_path,
-    #     subject_id="XFN1",
-    #     output_dir_path=output_dir_path,
-    #     stub_test=stub_test,
-    #     verbose=verbose,
-    # )
-    # session_to_nwb(
-    #     session_folder_path=session_folder_path,
-    #     subject_id="XFN3",
-    #     output_dir_path=output_dir_path,
-    #     stub_test=stub_test,
-    #     verbose=verbose,
-    # )
+    # Example Session Opaque
+    session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "Opaque" / "XFN1-XFN3" / "08-16-2023"
+    session_to_nwb(
+        session_folder_path=session_folder_path,
+        subject_id="XFN1",
+        output_dir_path=output_dir_path,
+        stub_test=stub_test,
+        verbose=verbose,
+    )
+    session_to_nwb(
+        session_folder_path=session_folder_path,
+        subject_id="XFN3",
+        output_dir_path=output_dir_path,
+        stub_test=stub_test,
+        verbose=verbose,
+    )
 
-    # # Example Session WT
-    # session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN2-XFN4" / "07-19-2023"
-    # session_to_nwb(
-    #     session_folder_path=session_folder_path,
-    #     subject_id="XFN2",
-    #     output_dir_path=output_dir_path,
-    #     stub_test=stub_test,
-    #     verbose=verbose,
-    # )
-    # session_to_nwb(
-    #     session_folder_path=session_folder_path,
-    #     subject_id="XFN4",
-    #     output_dir_path=output_dir_path,
-    #     stub_test=stub_test,
-    #     verbose=verbose,
-    # )
+    # Example Session WT
+    session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN2-XFN4" / "07-19-2023"
+    session_to_nwb(
+        session_folder_path=session_folder_path,
+        subject_id="XFN2",
+        output_dir_path=output_dir_path,
+        stub_test=stub_test,
+        verbose=verbose,
+    )
+    session_to_nwb(
+        session_folder_path=session_folder_path,
+        subject_id="XFN4",
+        output_dir_path=output_dir_path,
+        stub_test=stub_test,
+        verbose=verbose,
+    )
 
     # Example Session Single Epoch
     session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN2-XFN4" / "07-15-2023"
@@ -186,6 +190,23 @@ def main():
     session_to_nwb(
         session_folder_path=session_folder_path,
         subject_id="XFN4",
+        output_dir_path=output_dir_path,
+        stub_test=stub_test,
+        verbose=verbose,
+    )
+
+    # Example Session DIO-only
+    session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN1-XFN3" / "07-17-2023"
+    session_to_nwb(
+        session_folder_path=session_folder_path,
+        subject_id="XFN1",
+        output_dir_path=output_dir_path,
+        stub_test=stub_test,
+        verbose=verbose,
+    )
+    session_to_nwb(
+        session_folder_path=session_folder_path,
+        subject_id="XFN3",
         output_dir_path=output_dir_path,
         stub_test=stub_test,
         verbose=verbose,

--- a/src/jadhav_lab_to_nwb/rivera_and_shukla_2025/rivera_and_shukla_2025_convert_session.py
+++ b/src/jadhav_lab_to_nwb/rivera_and_shukla_2025/rivera_and_shukla_2025_convert_session.py
@@ -139,191 +139,210 @@ def main():
     stub_test = False
     verbose = True
 
-    # Example Session 100% reward
-    session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN1-XFN3" / "07-20-2023"
-    session_to_nwb(
-        session_folder_path=session_folder_path,
-        subject_id="XFN1",
-        output_dir_path=output_dir_path,
-        experimental_condition="100%",
-        stub_test=stub_test,
-        verbose=verbose,
-    )
+    # # Example Session 100% reward
+    # session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN1-XFN3" / "07-20-2023"
+    # session_to_nwb(
+    #     session_folder_path=session_folder_path,
+    #     subject_id="XFN1",
+    #     output_dir_path=output_dir_path,
+    #     experimental_condition="100%",
+    #     stub_test=stub_test,
+    #     verbose=verbose,
+    # )
 
-    session_to_nwb(
-        session_folder_path=session_folder_path,
-        subject_id="XFN3",
-        output_dir_path=output_dir_path,
-        experimental_condition="100%",
-        stub_test=stub_test,
-        verbose=verbose,
-    )
+    # session_to_nwb(
+    #     session_folder_path=session_folder_path,
+    #     subject_id="XFN3",
+    #     output_dir_path=output_dir_path,
+    #     experimental_condition="100%",
+    #     stub_test=stub_test,
+    #     verbose=verbose,
+    # )
 
-    # Example Session 50% reward
-    session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "50%" / "XFN1-XFN3" / "08-08-2023"
-    session_to_nwb(
-        session_folder_path=session_folder_path,
-        subject_id="XFN1",
-        output_dir_path=output_dir_path,
-        experimental_condition="50%",
-        stub_test=stub_test,
-        verbose=verbose,
-    )
-    session_to_nwb(
-        session_folder_path=session_folder_path,
-        subject_id="XFN3",
-        output_dir_path=output_dir_path,
-        experimental_condition="50%",
-        stub_test=stub_test,
-        verbose=verbose,
-    )
+    # # Example Session 50% reward
+    # session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "50%" / "XFN1-XFN3" / "08-08-2023"
+    # session_to_nwb(
+    #     session_folder_path=session_folder_path,
+    #     subject_id="XFN1",
+    #     output_dir_path=output_dir_path,
+    #     experimental_condition="50%",
+    #     stub_test=stub_test,
+    #     verbose=verbose,
+    # )
+    # session_to_nwb(
+    #     session_folder_path=session_folder_path,
+    #     subject_id="XFN3",
+    #     output_dir_path=output_dir_path,
+    #     experimental_condition="50%",
+    #     stub_test=stub_test,
+    #     verbose=verbose,
+    # )
 
-    # Example Session Opaque
-    session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "Opaque" / "XFN1-XFN3" / "08-16-2023"
-    session_to_nwb(
-        session_folder_path=session_folder_path,
-        subject_id="XFN1",
-        output_dir_path=output_dir_path,
-        experimental_condition="Opaque",
-        stub_test=stub_test,
-        verbose=verbose,
-    )
-    session_to_nwb(
-        session_folder_path=session_folder_path,
-        subject_id="XFN3",
-        output_dir_path=output_dir_path,
-        experimental_condition="Opaque",
-        stub_test=stub_test,
-        verbose=verbose,
-    )
+    # # Example Session Opaque
+    # session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "Opaque" / "XFN1-XFN3" / "08-16-2023"
+    # session_to_nwb(
+    #     session_folder_path=session_folder_path,
+    #     subject_id="XFN1",
+    #     output_dir_path=output_dir_path,
+    #     experimental_condition="Opaque",
+    #     stub_test=stub_test,
+    #     verbose=verbose,
+    # )
+    # session_to_nwb(
+    #     session_folder_path=session_folder_path,
+    #     subject_id="XFN3",
+    #     output_dir_path=output_dir_path,
+    #     experimental_condition="Opaque",
+    #     stub_test=stub_test,
+    #     verbose=verbose,
+    # )
 
-    # Example Session WT
-    session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN2-XFN4" / "07-19-2023"
+    # # Example Session WT
+    # session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN2-XFN4" / "07-19-2023"
+    # session_to_nwb(
+    #     session_folder_path=session_folder_path,
+    #     subject_id="XFN2",
+    #     output_dir_path=output_dir_path,
+    #     experimental_condition="100%",
+    #     stub_test=stub_test,
+    #     verbose=verbose,
+    # )
+    # session_to_nwb(
+    #     session_folder_path=session_folder_path,
+    #     subject_id="XFN4",
+    #     output_dir_path=output_dir_path,
+    #     experimental_condition="100%",
+    #     stub_test=stub_test,
+    #     verbose=verbose,
+    # )
+
+    # # Example Session Single Epoch
+    # session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN2-XFN4" / "07-15-2023"
+    # session_to_nwb(
+    #     session_folder_path=session_folder_path,
+    #     subject_id="XFN2",
+    #     output_dir_path=output_dir_path,
+    #     experimental_condition="100%",
+    #     stub_test=stub_test,
+    #     verbose=verbose,
+    # )
+    # session_to_nwb(
+    #     session_folder_path=session_folder_path,
+    #     subject_id="XFN4",
+    #     output_dir_path=output_dir_path,
+    #     experimental_condition="100%",
+    #     stub_test=stub_test,
+    #     verbose=verbose,
+    # )
+
+    # # Example Session DIO-only
+    # session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "50%" / "XFN1-XFN3" / "08-03-2023"
+    # session_to_nwb(
+    #     session_folder_path=session_folder_path,
+    #     subject_id="XFN1",
+    #     output_dir_path=output_dir_path,
+    #     experimental_condition="50%",
+    #     stub_test=stub_test,
+    #     verbose=verbose,
+    # )
+    # session_to_nwb(
+    #     session_folder_path=session_folder_path,
+    #     subject_id="XFN3",
+    #     output_dir_path=output_dir_path,
+    #     experimental_condition="50%",
+    #     stub_test=stub_test,
+    #     verbose=verbose,
+    # )
+
+    # # Example Session Multiple Videos for a single epoch
+    # session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN2-XFN4" / "07-24-2023"
+    # session_to_nwb(
+    #     session_folder_path=session_folder_path,
+    #     subject_id="XFN2",
+    #     output_dir_path=output_dir_path,
+    #     experimental_condition="100%",
+    #     stub_test=stub_test,
+    #     verbose=verbose,
+    # )
+    # session_to_nwb(
+    #     session_folder_path=session_folder_path,
+    #     subject_id="XFN4",
+    #     output_dir_path=output_dir_path,
+    #     experimental_condition="100%",
+    #     stub_test=stub_test,
+    #     verbose=verbose,
+    # )
+
+    # # Example Session with corrupted hdf5 files
+    # session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN1-XFN3" / "07-27-2023"
+    # session_to_nwb(
+    #     session_folder_path=session_folder_path,
+    #     subject_id="XFN1",
+    #     output_dir_path=output_dir_path,
+    #     experimental_condition="100%",
+    #     stub_test=stub_test,
+    #     verbose=verbose,
+    # )
+    # session_to_nwb(
+    #     session_folder_path=session_folder_path,
+    #     subject_id="XFN3",
+    #     output_dir_path=output_dir_path,
+    #     experimental_condition="100%",
+    #     stub_test=stub_test,
+    #     verbose=verbose,
+    # )
+
+    # # Example Session with incomplete epochs and mismatched timestamps
+    # session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN1-XFN3" / "07-15-2023"
+    # session_to_nwb(
+    #     session_folder_path=session_folder_path,
+    #     subject_id="XFN1",
+    #     output_dir_path=output_dir_path,
+    #     experimental_condition="100%",
+    #     stub_test=stub_test,
+    #     verbose=verbose,
+    # )
+    # session_to_nwb(
+    #     session_folder_path=session_folder_path,
+    #     subject_id="XFN3",
+    #     output_dir_path=output_dir_path,
+    #     experimental_condition="100%",
+    #     stub_test=stub_test,
+    #     verbose=verbose,
+    # )
+
+    # # Example Session with missing DLC epochs
+    # session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "50%" / "XFN1-XFN3" / "08-16-2023"
+    # session_to_nwb(
+    #     session_folder_path=session_folder_path,
+    #     subject_id="XFN1",
+    #     output_dir_path=output_dir_path,
+    #     experimental_condition="50%",
+    #     stub_test=stub_test,
+    #     verbose=verbose,
+    # )
+    # session_to_nwb(
+    #     session_folder_path=session_folder_path,
+    #     subject_id="XFN3",
+    #     output_dir_path=output_dir_path,
+    #     experimental_condition="50%",
+    #     stub_test=stub_test,
+    #     verbose=verbose,
+    # )
+
+    # Example Session with missing DLC segment
+    session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "50%" / "XFN2-XFN4" / "08-03-2023"
     session_to_nwb(
         session_folder_path=session_folder_path,
         subject_id="XFN2",
         output_dir_path=output_dir_path,
-        experimental_condition="100%",
+        experimental_condition="50%",
         stub_test=stub_test,
         verbose=verbose,
     )
     session_to_nwb(
         session_folder_path=session_folder_path,
         subject_id="XFN4",
-        output_dir_path=output_dir_path,
-        experimental_condition="100%",
-        stub_test=stub_test,
-        verbose=verbose,
-    )
-
-    # Example Session Single Epoch
-    session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN2-XFN4" / "07-15-2023"
-    session_to_nwb(
-        session_folder_path=session_folder_path,
-        subject_id="XFN2",
-        output_dir_path=output_dir_path,
-        experimental_condition="100%",
-        stub_test=stub_test,
-        verbose=verbose,
-    )
-    session_to_nwb(
-        session_folder_path=session_folder_path,
-        subject_id="XFN4",
-        output_dir_path=output_dir_path,
-        experimental_condition="100%",
-        stub_test=stub_test,
-        verbose=verbose,
-    )
-
-    # Example Session DIO-only
-    session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "50%" / "XFN1-XFN3" / "08-03-2023"
-    session_to_nwb(
-        session_folder_path=session_folder_path,
-        subject_id="XFN1",
-        output_dir_path=output_dir_path,
-        experimental_condition="50%",
-        stub_test=stub_test,
-        verbose=verbose,
-    )
-    session_to_nwb(
-        session_folder_path=session_folder_path,
-        subject_id="XFN3",
-        output_dir_path=output_dir_path,
-        experimental_condition="50%",
-        stub_test=stub_test,
-        verbose=verbose,
-    )
-
-    # Example Session Multiple Videos for a single epoch
-    session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN2-XFN4" / "07-24-2023"
-    session_to_nwb(
-        session_folder_path=session_folder_path,
-        subject_id="XFN2",
-        output_dir_path=output_dir_path,
-        experimental_condition="100%",
-        stub_test=stub_test,
-        verbose=verbose,
-    )
-    session_to_nwb(
-        session_folder_path=session_folder_path,
-        subject_id="XFN4",
-        output_dir_path=output_dir_path,
-        experimental_condition="100%",
-        stub_test=stub_test,
-        verbose=verbose,
-    )
-
-    # Example Session with corrupted hdf5 files
-    session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN1-XFN3" / "07-27-2023"
-    session_to_nwb(
-        session_folder_path=session_folder_path,
-        subject_id="XFN1",
-        output_dir_path=output_dir_path,
-        experimental_condition="100%",
-        stub_test=stub_test,
-        verbose=verbose,
-    )
-    session_to_nwb(
-        session_folder_path=session_folder_path,
-        subject_id="XFN3",
-        output_dir_path=output_dir_path,
-        experimental_condition="100%",
-        stub_test=stub_test,
-        verbose=verbose,
-    )
-
-    # Example Session with incomplete epochs and mismatched timestamps
-    session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN1-XFN3" / "07-15-2023"
-    session_to_nwb(
-        session_folder_path=session_folder_path,
-        subject_id="XFN1",
-        output_dir_path=output_dir_path,
-        experimental_condition="100%",
-        stub_test=stub_test,
-        verbose=verbose,
-    )
-    session_to_nwb(
-        session_folder_path=session_folder_path,
-        subject_id="XFN3",
-        output_dir_path=output_dir_path,
-        experimental_condition="100%",
-        stub_test=stub_test,
-        verbose=verbose,
-    )
-
-    # Example Session with missing DLC epochs
-    session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "50%" / "XFN1-XFN3" / "08-16-2023"
-    session_to_nwb(
-        session_folder_path=session_folder_path,
-        subject_id="XFN1",
-        output_dir_path=output_dir_path,
-        experimental_condition="50%",
-        stub_test=stub_test,
-        verbose=verbose,
-    )
-    session_to_nwb(
-        session_folder_path=session_folder_path,
-        subject_id="XFN3",
         output_dir_path=output_dir_path,
         experimental_condition="50%",
         stub_test=stub_test,

--- a/src/jadhav_lab_to_nwb/rivera_and_shukla_2025/rivera_and_shukla_2025_convert_session.py
+++ b/src/jadhav_lab_to_nwb/rivera_and_shukla_2025/rivera_and_shukla_2025_convert_session.py
@@ -36,9 +36,11 @@ def session_to_nwb(
 
     # Add Video
     file_paths = natsorted(list(dio_folder_path.glob("*.h264")))
+    # log07-15-2023(3-XFN3-XFN1).1.h264 is just a video of the mazes without behavior --> skipping
+    file_paths = [file_path for file_path in file_paths if file_path.name != "log07-15-2023(3-XFN3-XFN1).1.h264"]
     video_timestamps_file_paths = natsorted(list(dio_folder_path.glob("*.videoTimeStamps")))
     epoch_name_to_file_paths, epoch_name_to_timestamps_file_paths = {}, {}
-    for file_path, video_timestamps_file_path in zip(file_paths, video_timestamps_file_paths):
+    for file_path, video_timestamps_file_path in zip(file_paths, video_timestamps_file_paths, strict=True):
         file_epoch_name = rivera_and_shukla_2025_get_epoch_name(name=file_path.name)
         timestamps_epoch_name = rivera_and_shukla_2025_get_epoch_name(name=video_timestamps_file_path.name)
         assert file_epoch_name == timestamps_epoch_name, "Video files were not sorted correctly."
@@ -137,142 +139,161 @@ def main():
     stub_test = False
     verbose = True
 
-    # Example Session 100% reward
-    session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN1-XFN3" / "07-20-2023"
-    session_to_nwb(
-        session_folder_path=session_folder_path,
-        subject_id="XFN1",
-        output_dir_path=output_dir_path,
-        experimental_condition="100%",
-        stub_test=stub_test,
-        verbose=verbose,
-    )
+    # # Example Session 100% reward
+    # session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN1-XFN3" / "07-20-2023"
+    # session_to_nwb(
+    #     session_folder_path=session_folder_path,
+    #     subject_id="XFN1",
+    #     output_dir_path=output_dir_path,
+    #     experimental_condition="100%",
+    #     stub_test=stub_test,
+    #     verbose=verbose,
+    # )
 
-    session_to_nwb(
-        session_folder_path=session_folder_path,
-        subject_id="XFN3",
-        output_dir_path=output_dir_path,
-        experimental_condition="100%",
-        stub_test=stub_test,
-        verbose=verbose,
-    )
+    # session_to_nwb(
+    #     session_folder_path=session_folder_path,
+    #     subject_id="XFN3",
+    #     output_dir_path=output_dir_path,
+    #     experimental_condition="100%",
+    #     stub_test=stub_test,
+    #     verbose=verbose,
+    # )
 
-    # Example Session 50% reward
-    session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "50%" / "XFN1-XFN3" / "08-08-2023"
-    session_to_nwb(
-        session_folder_path=session_folder_path,
-        subject_id="XFN1",
-        output_dir_path=output_dir_path,
-        experimental_condition="50%",
-        stub_test=stub_test,
-        verbose=verbose,
-    )
-    session_to_nwb(
-        session_folder_path=session_folder_path,
-        subject_id="XFN3",
-        output_dir_path=output_dir_path,
-        experimental_condition="50%",
-        stub_test=stub_test,
-        verbose=verbose,
-    )
+    # # Example Session 50% reward
+    # session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "50%" / "XFN1-XFN3" / "08-08-2023"
+    # session_to_nwb(
+    #     session_folder_path=session_folder_path,
+    #     subject_id="XFN1",
+    #     output_dir_path=output_dir_path,
+    #     experimental_condition="50%",
+    #     stub_test=stub_test,
+    #     verbose=verbose,
+    # )
+    # session_to_nwb(
+    #     session_folder_path=session_folder_path,
+    #     subject_id="XFN3",
+    #     output_dir_path=output_dir_path,
+    #     experimental_condition="50%",
+    #     stub_test=stub_test,
+    #     verbose=verbose,
+    # )
 
-    # Example Session Opaque
-    session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "Opaque" / "XFN1-XFN3" / "08-16-2023"
-    session_to_nwb(
-        session_folder_path=session_folder_path,
-        subject_id="XFN1",
-        output_dir_path=output_dir_path,
-        experimental_condition="Opaque",
-        stub_test=stub_test,
-        verbose=verbose,
-    )
-    session_to_nwb(
-        session_folder_path=session_folder_path,
-        subject_id="XFN3",
-        output_dir_path=output_dir_path,
-        experimental_condition="Opaque",
-        stub_test=stub_test,
-        verbose=verbose,
-    )
+    # # Example Session Opaque
+    # session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "Opaque" / "XFN1-XFN3" / "08-16-2023"
+    # session_to_nwb(
+    #     session_folder_path=session_folder_path,
+    #     subject_id="XFN1",
+    #     output_dir_path=output_dir_path,
+    #     experimental_condition="Opaque",
+    #     stub_test=stub_test,
+    #     verbose=verbose,
+    # )
+    # session_to_nwb(
+    #     session_folder_path=session_folder_path,
+    #     subject_id="XFN3",
+    #     output_dir_path=output_dir_path,
+    #     experimental_condition="Opaque",
+    #     stub_test=stub_test,
+    #     verbose=verbose,
+    # )
 
-    # Example Session WT
-    session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN2-XFN4" / "07-19-2023"
-    session_to_nwb(
-        session_folder_path=session_folder_path,
-        subject_id="XFN2",
-        output_dir_path=output_dir_path,
-        experimental_condition="100%",
-        stub_test=stub_test,
-        verbose=verbose,
-    )
-    session_to_nwb(
-        session_folder_path=session_folder_path,
-        subject_id="XFN4",
-        output_dir_path=output_dir_path,
-        experimental_condition="100%",
-        stub_test=stub_test,
-        verbose=verbose,
-    )
+    # # Example Session WT
+    # session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN2-XFN4" / "07-19-2023"
+    # session_to_nwb(
+    #     session_folder_path=session_folder_path,
+    #     subject_id="XFN2",
+    #     output_dir_path=output_dir_path,
+    #     experimental_condition="100%",
+    #     stub_test=stub_test,
+    #     verbose=verbose,
+    # )
+    # session_to_nwb(
+    #     session_folder_path=session_folder_path,
+    #     subject_id="XFN4",
+    #     output_dir_path=output_dir_path,
+    #     experimental_condition="100%",
+    #     stub_test=stub_test,
+    #     verbose=verbose,
+    # )
 
-    # Example Session Single Epoch
-    session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN2-XFN4" / "07-15-2023"
-    session_to_nwb(
-        session_folder_path=session_folder_path,
-        subject_id="XFN2",
-        output_dir_path=output_dir_path,
-        experimental_condition="100%",
-        stub_test=stub_test,
-        verbose=verbose,
-    )
-    session_to_nwb(
-        session_folder_path=session_folder_path,
-        subject_id="XFN4",
-        output_dir_path=output_dir_path,
-        experimental_condition="100%",
-        stub_test=stub_test,
-        verbose=verbose,
-    )
+    # # Example Session Single Epoch
+    # session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN2-XFN4" / "07-15-2023"
+    # session_to_nwb(
+    #     session_folder_path=session_folder_path,
+    #     subject_id="XFN2",
+    #     output_dir_path=output_dir_path,
+    #     experimental_condition="100%",
+    #     stub_test=stub_test,
+    #     verbose=verbose,
+    # )
+    # session_to_nwb(
+    #     session_folder_path=session_folder_path,
+    #     subject_id="XFN4",
+    #     output_dir_path=output_dir_path,
+    #     experimental_condition="100%",
+    #     stub_test=stub_test,
+    #     verbose=verbose,
+    # )
 
-    # Example Session DIO-only
-    session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN1-XFN3" / "07-17-2023"
-    session_to_nwb(
-        session_folder_path=session_folder_path,
-        subject_id="XFN1",
-        output_dir_path=output_dir_path,
-        experimental_condition="100%",
-        stub_test=stub_test,
-        verbose=verbose,
-    )
-    session_to_nwb(
-        session_folder_path=session_folder_path,
-        subject_id="XFN3",
-        output_dir_path=output_dir_path,
-        experimental_condition="100%",
-        stub_test=stub_test,
-        verbose=verbose,
-    )
+    # # Example Session DIO-only
+    # session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN1-XFN3" / "07-17-2023"
+    # session_to_nwb(
+    #     session_folder_path=session_folder_path,
+    #     subject_id="XFN1",
+    #     output_dir_path=output_dir_path,
+    #     experimental_condition="100%",
+    #     stub_test=stub_test,
+    #     verbose=verbose,
+    # )
+    # session_to_nwb(
+    #     session_folder_path=session_folder_path,
+    #     subject_id="XFN3",
+    #     output_dir_path=output_dir_path,
+    #     experimental_condition="100%",
+    #     stub_test=stub_test,
+    #     verbose=verbose,
+    # )
 
-    # Example Session Multiple Videos for a single epoch
-    session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN2-XFN4" / "07-24-2023"
-    session_to_nwb(
-        session_folder_path=session_folder_path,
-        subject_id="XFN2",
-        output_dir_path=output_dir_path,
-        experimental_condition="100%",
-        stub_test=stub_test,
-        verbose=verbose,
-    )
-    session_to_nwb(
-        session_folder_path=session_folder_path,
-        subject_id="XFN4",
-        output_dir_path=output_dir_path,
-        experimental_condition="100%",
-        stub_test=stub_test,
-        verbose=verbose,
-    )
+    # # Example Session Multiple Videos for a single epoch
+    # session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN2-XFN4" / "07-24-2023"
+    # session_to_nwb(
+    #     session_folder_path=session_folder_path,
+    #     subject_id="XFN2",
+    #     output_dir_path=output_dir_path,
+    #     experimental_condition="100%",
+    #     stub_test=stub_test,
+    #     verbose=verbose,
+    # )
+    # session_to_nwb(
+    #     session_folder_path=session_folder_path,
+    #     subject_id="XFN4",
+    #     output_dir_path=output_dir_path,
+    #     experimental_condition="100%",
+    #     stub_test=stub_test,
+    #     verbose=verbose,
+    # )
 
-    # Example Session with corrupted hdf5 files
-    session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN1-XFN3" / "07-27-2023"
+    # # Example Session with corrupted hdf5 files
+    # session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN1-XFN3" / "07-27-2023"
+    # session_to_nwb(
+    #     session_folder_path=session_folder_path,
+    #     subject_id="XFN1",
+    #     output_dir_path=output_dir_path,
+    #     experimental_condition="100%",
+    #     stub_test=stub_test,
+    #     verbose=verbose,
+    # )
+    # session_to_nwb(
+    #     session_folder_path=session_folder_path,
+    #     subject_id="XFN3",
+    #     output_dir_path=output_dir_path,
+    #     experimental_condition="100%",
+    #     stub_test=stub_test,
+    #     verbose=verbose,
+    # )
+
+    # Example Session with incomplete epochs and mismatched timestamps
+    session_folder_path = data_dir_path / "CohortAS1" / "Social W" / "100%" / "XFN1-XFN3" / "07-15-2023"
     session_to_nwb(
         session_folder_path=session_folder_path,
         subject_id="XFN1",

--- a/src/jadhav_lab_to_nwb/rivera_and_shukla_2025/rivera_and_shukla_2025_dlc_interface.py
+++ b/src/jadhav_lab_to_nwb/rivera_and_shukla_2025/rivera_and_shukla_2025_dlc_interface.py
@@ -29,9 +29,10 @@ class RiveraAndShukla2025DeepLabCutInterface(BaseDeepLabCutInterface):
 
     def get_pose_estimation_metadata_key(self, file_name: str, subject_id: str | None = None) -> str:
         epoch_name = rivera_and_shukla_2025_get_epoch_name(name=file_name)
+        segment_number = file_name.split(").")[1].split("DLC")[0]
         epoch_number, subject_id1, subject_id2 = epoch_name.split("-")
         subject_id = subject_id1 if subject_id1 == subject_id else subject_id2
-        pose_estimation_metadata_key = f"PoseEstimation_{epoch_number}-{subject_id}"
+        pose_estimation_metadata_key = f"PoseEstimation_{epoch_number}-{subject_id}-{segment_number}"
         return pose_estimation_metadata_key
 
     def get_task_name(self, dlc_interface) -> str:

--- a/src/jadhav_lab_to_nwb/rivera_and_shukla_2025/rivera_and_shukla_2025_epoch_interface.py
+++ b/src/jadhav_lab_to_nwb/rivera_and_shukla_2025/rivera_and_shukla_2025_epoch_interface.py
@@ -13,11 +13,11 @@ class RiveraAndShukla2025EpochInterface(BaseEpochInterface):
         video_timestamps_file_paths = self.source_data["video_timestamps_file_paths"]
         subject_id = metadata["Subject"]["subject_id"]
 
-        for epoch_timestamps, video_timestamps_file_path in zip(timestamps, video_timestamps_file_paths):
-            epoch_name = rivera_and_shukla_2025_get_epoch_name(video_timestamps_file_path.name)
+        for epoch_timestamps, epoch_video_timestamps_file_paths in zip(timestamps, video_timestamps_file_paths):
+            epoch_name = rivera_and_shukla_2025_get_epoch_name(epoch_video_timestamps_file_paths[0].name)
             epoch_number, subject_id1, subject_id2 = epoch_name.split("-")
-            start_time = epoch_timestamps[0]
-            stop_time = epoch_timestamps[-1]
+            start_time = epoch_timestamps[0][0]
+            stop_time = epoch_timestamps[-1][-1]
             tag = f"{int(epoch_number):02d}"  # Spyglass requires 2-digit string epoch numbers
             nwbfile.add_epoch(
                 start_time=start_time,

--- a/src/jadhav_lab_to_nwb/rivera_and_shukla_2025/rivera_and_shukla_2025_insert_all_sessions.py
+++ b/src/jadhav_lab_to_nwb/rivera_and_shukla_2025/rivera_and_shukla_2025_insert_all_sessions.py
@@ -1,0 +1,49 @@
+"""Primary script to insert all sessions into the spyglass database."""
+
+import datajoint as dj
+from pathlib import Path
+import sys
+from tqdm import tqdm
+
+dj_local_conf_path = "/Users/pauladkisson/Documents/CatalystNeuro/JadhavConv/jadhav-lab-to-nwb/src/jadhav_lab_to_nwb/spyglass_mock/dj_local_conf.json"
+dj.config.load(dj_local_conf_path)  # load config for database connection info
+
+# General Spyglass Imports
+import spyglass.common as sgc  # this import connects to the database
+
+# Custom Table Imports
+sys.path.append(
+    "/Users/pauladkisson/Documents/CatalystNeuro/JadhavConv/jadhav-lab-to-nwb/src/jadhav_lab_to_nwb/spyglass_extensions"
+)
+from task_leds import TaskLEDs
+
+sys.path.append(
+    "/Users/pauladkisson/Documents/CatalystNeuro/JadhavConv/jadhav-lab-to-nwb/src/jadhav_lab_to_nwb/rivera_and_shukla_2025"
+)
+from rivera_and_shukla_2025_insert_session import insert_session
+
+
+def main():
+    # Suppress logging and warnings for cleaner progress bar
+    import logging
+    import warnings
+
+    logging.disable(logging.CRITICAL)
+    warnings.filterwarnings("ignore")
+
+    sgc.Nwbfile.delete()
+    sgc.Task.delete()
+    TaskLEDs.delete()
+    spyglass_raw_path = Path("/Volumes/T7/CatalystNeuro/Spyglass/raw")
+    subject_ids = ["XFN1", "XFN2", "XFN3", "XFN4"]
+    nwbfile_paths = []
+    for subject_id in subject_ids:
+        nwbfile_paths.extend(spyglass_raw_path.glob(f"sub-{subject_id}_ses-*.nwb"))
+    nwbfile_paths = sorted(nwbfile_paths)
+    for nwbfile_path in tqdm(nwbfile_paths, desc="Inserting sessions"):
+        insert_session(nwbfile_path, rollback_on_fail=False, raise_err=False)
+
+
+if __name__ == "__main__":
+    main()
+    print("Done!")

--- a/src/jadhav_lab_to_nwb/rivera_and_shukla_2025/rivera_and_shukla_2025_insert_session.py
+++ b/src/jadhav_lab_to_nwb/rivera_and_shukla_2025/rivera_and_shukla_2025_insert_session.py
@@ -16,7 +16,7 @@ from spyglass.utils.nwb_helper_fn import get_nwb_copy_filename
 
 # Custom Table Imports
 sys.path.append(
-    "/Users/pauladkisson/Documents/CatalystNeuro/JadhavConv/jadhav-lab-to-nwb/src/jadhav_lab_to_nwb/rivera_and_shukla_2025/spyglass_extensions"
+    "/Users/pauladkisson/Documents/CatalystNeuro/JadhavConv/jadhav-lab-to-nwb/src/jadhav_lab_to_nwb/spyglass_extensions"
 )
 from task_leds import TaskLEDs
 
@@ -116,7 +116,7 @@ def test_video(nwbfile_path: Path):
 
 
 def main():
-    nwbfile_path = Path("/Volumes/T7/CatalystNeuro/Spyglass/raw/sub-XFN1_ses-07-20-2023.nwb")
+    nwbfile_path = Path("/Volumes/T7/CatalystNeuro/Spyglass/raw/sub-XFN4_ses-07-24-2023.nwb")
     nwb_copy_file_name = get_nwb_copy_filename(nwbfile_path.name)
 
     (sgc.Nwbfile & {"nwb_file_name": nwb_copy_file_name}).delete()

--- a/src/jadhav_lab_to_nwb/rivera_and_shukla_2025/rivera_and_shukla_2025_insert_session.py
+++ b/src/jadhav_lab_to_nwb/rivera_and_shukla_2025/rivera_and_shukla_2025_insert_session.py
@@ -116,7 +116,7 @@ def test_video(nwbfile_path: Path):
 
 
 def main():
-    nwbfile_path = Path("/Volumes/T7/CatalystNeuro/Spyglass/raw/sub-XFN4_ses-07-24-2023.nwb")
+    nwbfile_path = Path("/Volumes/T7/CatalystNeuro/Spyglass/raw/sub-XFN1_ses-07-20-2023.nwb")
     nwb_copy_file_name = get_nwb_copy_filename(nwbfile_path.name)
 
     (sgc.Nwbfile & {"nwb_file_name": nwb_copy_file_name}).delete()

--- a/src/jadhav_lab_to_nwb/rivera_and_shukla_2025/rivera_and_shukla_2025_metadata.yaml
+++ b/src/jadhav_lab_to_nwb/rivera_and_shukla_2025/rivera_and_shukla_2025_metadata.yaml
@@ -5,7 +5,6 @@ NWBFile:
     Individuals with autism spectrum disorders have severe cognitive and social deficits.
     However, little is known about the underlying causes and neural mechanisms associated with these deficits.
     Our study involves looking into the behavior of wild-type and Fmr1-/y rat pairs on W mazes where they are required to cooperate in order to get a joint reward.
-  session_description: Rats performed a cooperative maze task in which a pair of rats must cooperate by picking the same well in order to get a joint reward. Rewards were delivered 100% of the time when both rats poked the same well.
   institution: Brandeis University
   lab: Jadhav
   experimenter:
@@ -13,6 +12,12 @@ NWBFile:
     - Rivera, Edward L.
     - Bladon, John H.
     - Jadhav, Shantanu P.
+
+SessionMaps:
+   condition_to_session_description:
+    100%: Rats performed a cooperative maze task in which a pair of rats must cooperate by picking the same well in order to get a joint reward. Rewards were delivered 100% of the time when both rats poked the same well.
+    50%: Rats performed a cooperative maze task in which a pair of rats must cooperate by picking the same well in order to get a joint reward. Rewards were delivered 50% of the time when both rats poked the same well.
+    Opaque: Rats performed a cooperative maze task in which a pair of rats must cooperate by picking the same well in order to get a joint reward. Rewards were delivered 100% of the time when both rats poked the same well, but an opaque barrier was placed between the two mazes so the rats could not see each other.
 
 Subject:
   description: Long Evans Rat

--- a/src/jadhav_lab_to_nwb/rivera_and_shukla_2025/rivera_and_shukla_2025_notes.md
+++ b/src/jadhav_lab_to_nwb/rivera_and_shukla_2025/rivera_and_shukla_2025_notes.md
@@ -27,3 +27,6 @@
 - nose pokes are recorded for each well "Poke in wellB", "Poke in well1", etc.
 - matched pokes are recorded and delivered rewards "Matched pokes in position B2" unless it is followed by "but, no reward" in the next line
 - Spyglass DIOEvents depends on ephys, but the example data provided doesn't have ephys... --> what to do, what to do?
+
+## Edge cases
+- One of the sessions (CoopLearnProject/CohortAS1/Social W/100%/XFN2-XFN4/07-14-2023) has a different number of timestamps for video and DLC

--- a/src/jadhav_lab_to_nwb/rivera_and_shukla_2025/rivera_and_shukla_2025_notes.md
+++ b/src/jadhav_lab_to_nwb/rivera_and_shukla_2025/rivera_and_shukla_2025_notes.md
@@ -66,3 +66,4 @@
         CoopLearnProject/CohortAS1/Social W/100%/XFN2-XFN4/07-27-2023
 - Some of the sessions (ex. CoopLearnProject/CohortAS1/Social W/50%/XFN1-XFN3/08-07-2023) have multiple videos/epoch
     - Added support for multi-segment epochs
+- The XFN1-XFN3/07-17-2023 folder has 07-15-2023 data in it

--- a/src/jadhav_lab_to_nwb/rivera_and_shukla_2025/rivera_and_shukla_2025_notes.md
+++ b/src/jadhav_lab_to_nwb/rivera_and_shukla_2025/rivera_and_shukla_2025_notes.md
@@ -29,4 +29,9 @@
 - Spyglass DIOEvents depends on ephys, but the example data provided doesn't have ephys... --> what to do, what to do?
 
 ## Edge cases
-- One of the sessions (CoopLearnProject/CohortAS1/Social W/100%/XFN2-XFN4/07-14-2023) has a different number of timestamps for video and DLC
+- Some of the sessions (ex. CoopLearnProject/CohortAS1/Social W/100%/XFN2-XFN4/07-14-2023) has a different number of timestamps for video and DLC
+- Some of the sessions (ex. CoopLearnProject/CohortAS1/Social W/50%/XFN1-XFN3/08-16-2023) are missing DLC epochs
+- Some of the sessions (ex. CoopLearnProject/CohortAS1/Social W/100%/XFN1-XFN3/07-15-2023) have incomplete epochs
+- Some of the sessions (ex. CoopLearnProject/CohortAS1/Social W/100%/XFN1-XFN3/07-27-2023) have corrupted hdf5 files
+- Some of the sessions (ex. CoopLearnProject/CohortAS1/Social W/50%/XFN1-XFN3/08-07-2023) have multiple videos/epoch
+    - Looks like the video got interrupted for some reason so there are 2 videos/timestamps for a single epoch

--- a/src/jadhav_lab_to_nwb/rivera_and_shukla_2025/rivera_and_shukla_2025_notes.md
+++ b/src/jadhav_lab_to_nwb/rivera_and_shukla_2025/rivera_and_shukla_2025_notes.md
@@ -68,3 +68,4 @@
     - Added support for multi-segment epochs
 - The XFN1-XFN3/07-17-2023 folder has 07-15-2023 data in it --> skipping
 - One session (CohortAS1/Social W/50%/XFN2-XFN4/08-03-2023) has a missing DLC segment
+- One session (CohortAS1/Social W/50%/XFN2-XFN4/09-21-2023) has ~~~ at the end of the behavior file

--- a/src/jadhav_lab_to_nwb/rivera_and_shukla_2025/rivera_and_shukla_2025_notes.md
+++ b/src/jadhav_lab_to_nwb/rivera_and_shukla_2025/rivera_and_shukla_2025_notes.md
@@ -32,6 +32,7 @@
 - Some of the sessions (ex. CoopLearnProject/CohortAS1/Social W/100%/XFN2-XFN4/07-14-2023) has a different number of timestamps for video and DLC
 - Some of the sessions (ex. CoopLearnProject/CohortAS1/Social W/50%/XFN1-XFN3/08-16-2023) are missing DLC epochs
 - Some of the sessions (ex. CoopLearnProject/CohortAS1/Social W/100%/XFN1-XFN3/07-15-2023) have incomplete epochs
-- Some of the sessions (ex. CoopLearnProject/CohortAS1/Social W/100%/XFN1-XFN3/07-27-2023) have corrupted hdf5 files
+- Some of the sessions (ex. CoopLearnProject/CohortAS1/Social W/100%/XFN1-XFN3/07-27-2023) have corrupted hdf5 (and csv) files
+    - Skipping corrupted DLC
 - Some of the sessions (ex. CoopLearnProject/CohortAS1/Social W/50%/XFN1-XFN3/08-07-2023) have multiple videos/epoch
-    - Looks like the video got interrupted for some reason so there are 2 videos/timestamps for a single epoch
+    - Added support for multi-segment epochs

--- a/src/jadhav_lab_to_nwb/rivera_and_shukla_2025/rivera_and_shukla_2025_notes.md
+++ b/src/jadhav_lab_to_nwb/rivera_and_shukla_2025/rivera_and_shukla_2025_notes.md
@@ -66,4 +66,5 @@
         CoopLearnProject/CohortAS1/Social W/100%/XFN2-XFN4/07-27-2023
 - Some of the sessions (ex. CoopLearnProject/CohortAS1/Social W/50%/XFN1-XFN3/08-07-2023) have multiple videos/epoch
     - Added support for multi-segment epochs
-- The XFN1-XFN3/07-17-2023 folder has 07-15-2023 data in it
+- The XFN1-XFN3/07-17-2023 folder has 07-15-2023 data in it --> skipping
+- One session (CohortAS1/Social W/50%/XFN2-XFN4/08-03-2023) has a missing DLC segment

--- a/src/jadhav_lab_to_nwb/rivera_and_shukla_2025/rivera_and_shukla_2025_notes.md
+++ b/src/jadhav_lab_to_nwb/rivera_and_shukla_2025/rivera_and_shukla_2025_notes.md
@@ -29,7 +29,14 @@
 - Spyglass DIOEvents depends on ephys, but the example data provided doesn't have ephys... --> what to do, what to do?
 
 ## Edge cases
-- One of the sessions (CoopLearnProject/CohortAS1/Social W/100%/XFN2-XFN4/07-14-2023) has a different number of timestamps for video and DLC
+- Some of the sessions (ex. CoopLearnProject/CohortAS1/Social W/100%/XFN2-XFN4/07-14-2023) has a different number of timestamps for video and DLC
+    - Full List
+        CoopLearnProject/CohortAS1/Social W/100%/XFN1-XFN3/07-14-2023
+        CoopLearnProject/CohortAS1/Social W/100%/XFN1-XFN3/07-21-2023
+        CoopLearnProject/CohortAS1/Social W/100%/XFN2-XFN4/07-14-2023
+        CoopLearnProject/CohortAS1/Social W/100%/XFN2-XFN4/07-31-2023
+        CoopLearnProject/CohortAS1/Social W/50%/XFN2-XFN4/08-24-2023
+        CoopLearnProject/CohortAS1/Social W/50%/XFN2-XFN4/08-30-2023
 - Some of the sessions (ex. CoopLearnProject/CohortAS1/Social W/50%/XFN1-XFN3/08-16-2023) are missing DLC epochs
     - Full List
         CoopLearnProject/CohortAS1/Social W/50%/XFN1-XFN3/08-16-2023
@@ -51,6 +58,7 @@
         CoopLearnProject/CohortAS1/Social W/50%/XFN2-XFN4/09-13-2023
         CoopLearnProject/CohortAS1/Social W/50%/XFN2-XFN4/09-14-2023
 - One of the sessions (ex. CoopLearnProject/CohortAS1/Social W/100%/XFN1-XFN3/07-15-2023) have incomplete epochs
+    - This is just a video of the mazes without behavior --> skipping
 - 2 of the sessions (ex. CoopLearnProject/CohortAS1/Social W/100%/XFN1-XFN3/07-27-2023) have corrupted hdf5 (and csv) files
     - Skipping corrupted DLC
     - Full List

--- a/src/jadhav_lab_to_nwb/rivera_and_shukla_2025/rivera_and_shukla_2025_notes.md
+++ b/src/jadhav_lab_to_nwb/rivera_and_shukla_2025/rivera_and_shukla_2025_notes.md
@@ -29,10 +29,32 @@
 - Spyglass DIOEvents depends on ephys, but the example data provided doesn't have ephys... --> what to do, what to do?
 
 ## Edge cases
-- Some of the sessions (ex. CoopLearnProject/CohortAS1/Social W/100%/XFN2-XFN4/07-14-2023) has a different number of timestamps for video and DLC
+- One of the sessions (CoopLearnProject/CohortAS1/Social W/100%/XFN2-XFN4/07-14-2023) has a different number of timestamps for video and DLC
 - Some of the sessions (ex. CoopLearnProject/CohortAS1/Social W/50%/XFN1-XFN3/08-16-2023) are missing DLC epochs
-- Some of the sessions (ex. CoopLearnProject/CohortAS1/Social W/100%/XFN1-XFN3/07-15-2023) have incomplete epochs
-- Some of the sessions (ex. CoopLearnProject/CohortAS1/Social W/100%/XFN1-XFN3/07-27-2023) have corrupted hdf5 (and csv) files
+    - Full List
+        CoopLearnProject/CohortAS1/Social W/50%/XFN1-XFN3/08-16-2023
+        CoopLearnProject/CohortAS1/Social W/50%/XFN1-XFN3/09-06-2023
+        CoopLearnProject/CohortAS1/Social W/50%/XFN1-XFN3/09-13-2023
+        CoopLearnProject/CohortAS1/Social W/50%/XFN1-XFN3/09-14-2023
+        CoopLearnProject/CohortAS1/Social W/50%/XFN1-XFN3/09-15-2023
+        CoopLearnProject/CohortAS1/Social W/50%/XFN1-XFN3/09-18-2023
+        CoopLearnProject/CohortAS1/Social W/50%/XFN1-XFN3/09-20-2023
+        CoopLearnProject/CohortAS1/Social W/50%/XFN1-XFN3/09-21-2023
+        CoopLearnProject/CohortAS1/Social W/50%/XFN1-XFN3/09-22-2023
+        CoopLearnProject/CohortAS1/Social W/50%/XFN2-XFN4/08-03-2023
+        CoopLearnProject/CohortAS1/Social W/50%/XFN2-XFN4/08-17-2023
+        CoopLearnProject/CohortAS1/Social W/50%/XFN2-XFN4/08-18-2023
+        CoopLearnProject/CohortAS1/Social W/50%/XFN2-XFN4/08-28-2023
+        CoopLearnProject/CohortAS1/Social W/50%/XFN2-XFN4/08-29-2023
+        CoopLearnProject/CohortAS1/Social W/50%/XFN2-XFN4/09-01-2023
+        CoopLearnProject/CohortAS1/Social W/50%/XFN2-XFN4/09-06-2023
+        CoopLearnProject/CohortAS1/Social W/50%/XFN2-XFN4/09-13-2023
+        CoopLearnProject/CohortAS1/Social W/50%/XFN2-XFN4/09-14-2023
+- One of the sessions (ex. CoopLearnProject/CohortAS1/Social W/100%/XFN1-XFN3/07-15-2023) have incomplete epochs
+- 2 of the sessions (ex. CoopLearnProject/CohortAS1/Social W/100%/XFN1-XFN3/07-27-2023) have corrupted hdf5 (and csv) files
     - Skipping corrupted DLC
+    - Full List
+        CoopLearnProject/CohortAS1/Social W/100%/XFN1-XFN3/07-27-2023
+        CoopLearnProject/CohortAS1/Social W/100%/XFN2-XFN4/07-27-2023
 - Some of the sessions (ex. CoopLearnProject/CohortAS1/Social W/50%/XFN1-XFN3/08-07-2023) have multiple videos/epoch
     - Added support for multi-segment epochs

--- a/src/jadhav_lab_to_nwb/rivera_and_shukla_2025/rivera_and_shukla_2025_nwbconverter.py
+++ b/src/jadhav_lab_to_nwb/rivera_and_shukla_2025/rivera_and_shukla_2025_nwbconverter.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import pandas as pd
 import numpy as np
 import warnings
+from natsort import natsorted
 
 from jadhav_lab_to_nwb.rivera_and_shukla_2025 import (
     RiveraAndShukla2025BehaviorInterface,
@@ -13,6 +14,7 @@ from jadhav_lab_to_nwb.rivera_and_shukla_2025 import (
 )
 
 from ..tools.spikegadgets import readCameraModuleTimeStamps
+from ..utils.utils import rivera_and_shukla_2025_get_epoch_name
 
 
 class RiveraAndShukla2025NWBConverter(NWBConverter):
@@ -27,6 +29,25 @@ class RiveraAndShukla2025NWBConverter(NWBConverter):
     )
 
     def temporally_align_data_interfaces(self, metadata: dict | None = None, conversion_options: dict | None = None):
+        if "DeepLabCut1" in self.data_interface_objects:
+            epoch_name_to_dlc1_interfaces = {}
+            for dlc_interface in self.data_interface_objects["DeepLabCut1"].dlc_interfaces:
+                file_path = Path(dlc_interface.source_data["file_path"])
+                epoch_name = rivera_and_shukla_2025_get_epoch_name(name=file_path.name)
+                if epoch_name not in epoch_name_to_dlc1_interfaces:
+                    epoch_name_to_dlc1_interfaces[epoch_name] = [dlc_interface]
+                else:
+                    epoch_name_to_dlc1_interfaces[epoch_name].append(dlc_interface)
+        if "DeepLabCut2" in self.data_interface_objects:
+            epoch_name_to_dlc2_interfaces = {}
+            for dlc_interface in self.data_interface_objects["DeepLabCut2"].dlc_interfaces:
+                file_path = Path(dlc_interface.source_data["file_path"])
+                epoch_name = rivera_and_shukla_2025_get_epoch_name(name=file_path.name)
+                if epoch_name not in epoch_name_to_dlc2_interfaces:
+                    epoch_name_to_dlc2_interfaces[epoch_name] = [dlc_interface]
+                else:
+                    epoch_name_to_dlc2_interfaces[epoch_name].append(dlc_interface)
+
         video_timestamps_file_paths = self.data_interface_objects["Video"].video_timestamps_file_paths
 
         # Check for clock resets
@@ -52,12 +73,17 @@ class RiveraAndShukla2025NWBConverter(NWBConverter):
                 i += 1
 
         # Align interface timestamps
+        epoch_name_to_video_interface = {}
         video_interfaces = self.data_interface_objects["Video"].video_interfaces
         aligned_timestamps, starting_time_shifts, clock_rates, starting_frames = [], [], [], []
         i = 0
-        for epoch_video_timestamps_file_paths, video_interface in zip(video_timestamps_file_paths, video_interfaces):
+        for epoch_video_timestamps_file_paths, video_interface in zip(
+            video_timestamps_file_paths, video_interfaces, strict=True
+        ):
             if not isinstance(epoch_video_timestamps_file_paths, list):
                 epoch_video_timestamps_file_paths = [epoch_video_timestamps_file_paths]
+            epoch_name = rivera_and_shukla_2025_get_epoch_name(name=Path(epoch_video_timestamps_file_paths[0]).name)
+            epoch_name_to_video_interface[epoch_name] = video_interface
 
             epoch_timestamps, epoch_clock_rates, epoch_starting_time_shifts, epoch_starting_frames = [], [], [], []
             for segment_index, timestamp_file_path in enumerate(epoch_video_timestamps_file_paths):
@@ -79,13 +105,6 @@ class RiveraAndShukla2025NWBConverter(NWBConverter):
                 epoch_clock_rates.append(clock_rate)
                 epoch_starting_time_shifts.append(starting_time_shift)
                 epoch_starting_frames.append(starting_frame)
-
-                if "DeepLabCut1" in self.data_interface_objects:
-                    dlc1_interface = self.data_interface_objects["DeepLabCut1"].dlc_interfaces[i]
-                    self.align_dlc_interface(aligned_timestamps=timestamps, dlc_interface=dlc1_interface)
-                if "DeepLabCut2" in self.data_interface_objects:
-                    dlc2_interface = self.data_interface_objects["DeepLabCut2"].dlc_interfaces[i]
-                    self.align_dlc_interface(aligned_timestamps=timestamps, dlc_interface=dlc2_interface)
                 i += 1
             aligned_timestamps.append(epoch_timestamps)
             starting_time_shifts.append(epoch_starting_time_shifts[0])
@@ -100,6 +119,19 @@ class RiveraAndShukla2025NWBConverter(NWBConverter):
             starting_time_shifts=starting_time_shifts
         )
         self.data_interface_objects["Behavior"].set_clock_rates(clock_rates=clock_rates)
+
+        if "DeepLabCut1" in self.data_interface_objects:
+            for epoch_name, dlc1_interfaces in epoch_name_to_dlc1_interfaces.items():
+                video_interface = epoch_name_to_video_interface[epoch_name]
+                aligned_timestamps = video_interface.get_timestamps()
+                for dlc_interface, timestamps in zip(dlc1_interfaces, aligned_timestamps, strict=True):
+                    self.align_dlc_interface(timestamps, dlc_interface)
+        if "DeepLabCut2" in self.data_interface_objects:
+            for epoch_name, dlc2_interfaces in epoch_name_to_dlc2_interfaces.items():
+                video_interface = epoch_name_to_video_interface[epoch_name]
+                aligned_timestamps = video_interface.get_timestamps()
+                for dlc_interface, timestamps in zip(dlc2_interfaces, aligned_timestamps, strict=True):
+                    self.align_dlc_interface(timestamps, dlc_interface)
 
     def align_dlc_interface(self, aligned_timestamps: np.ndarray, dlc_interface):
         file_path = Path(dlc_interface.source_data["file_path"])

--- a/src/jadhav_lab_to_nwb/rivera_and_shukla_2025/rivera_and_shukla_2025_nwbconverter.py
+++ b/src/jadhav_lab_to_nwb/rivera_and_shukla_2025/rivera_and_shukla_2025_nwbconverter.py
@@ -23,7 +23,6 @@ class RiveraAndShukla2025NWBConverter(NWBConverter):
     )
 
     def temporally_align_data_interfaces(self, metadata: dict | None = None, conversion_options: dict | None = None):
-        # TODO: Add support for multi-segment DLC and make sure changes don't break olson_2024
         video_timestamps_file_paths = self.data_interface_objects["Video"].video_timestamps_file_paths
 
         # Check for clock resets

--- a/src/jadhav_lab_to_nwb/rivera_and_shukla_2025/rivera_and_shukla_2025_nwbconverter.py
+++ b/src/jadhav_lab_to_nwb/rivera_and_shukla_2025/rivera_and_shukla_2025_nwbconverter.py
@@ -120,13 +120,21 @@ class RiveraAndShukla2025NWBConverter(NWBConverter):
             for epoch_name, dlc1_interfaces in epoch_name_to_dlc1_interfaces.items():
                 video_interface = epoch_name_to_video_interface[epoch_name]
                 aligned_timestamps = video_interface.get_timestamps()
-                for dlc_interface, timestamps in zip(dlc1_interfaces, aligned_timestamps, strict=True):
+                for dlc_interface in dlc1_interfaces:
+                    file_path = Path(dlc_interface.source_data["file_path"])
+                    segment_number = file_path.name.split(").")[1].split("DLC")[0]
+                    segment_index = int(segment_number) - 1
+                    timestamps = aligned_timestamps[segment_index]
                     self.align_dlc_interface(timestamps, dlc_interface)
         if "DeepLabCut2" in self.data_interface_objects:
             for epoch_name, dlc2_interfaces in epoch_name_to_dlc2_interfaces.items():
                 video_interface = epoch_name_to_video_interface[epoch_name]
                 aligned_timestamps = video_interface.get_timestamps()
-                for dlc_interface, timestamps in zip(dlc2_interfaces, aligned_timestamps, strict=True):
+                for dlc_interface in dlc2_interfaces:
+                    file_path = Path(dlc_interface.source_data["file_path"])
+                    segment_number = file_path.name.split(").")[1].split("DLC")[0]
+                    segment_index = int(segment_number) - 1
+                    timestamps = aligned_timestamps[segment_index]
                     self.align_dlc_interface(timestamps, dlc_interface)
 
     def get_epoch_name_mappings(self):

--- a/src/jadhav_lab_to_nwb/rivera_and_shukla_2025/rivera_and_shukla_2025_nwbconverter.py
+++ b/src/jadhav_lab_to_nwb/rivera_and_shukla_2025/rivera_and_shukla_2025_nwbconverter.py
@@ -28,40 +28,70 @@ class RiveraAndShukla2025NWBConverter(NWBConverter):
         # Check for clock resets
         INTER_EPOCH_INTERVAL = 1800  # Typical interval between epochs in seconds
         start_times, stop_times, clock_resets = [], [], []
-        for i, video_timestamps_file_path in enumerate(video_timestamps_file_paths):
-            timestamps, _ = readCameraModuleTimeStamps(video_timestamps_file_path)
-            start_time = timestamps[0]
-            stop_time = timestamps[-1]
-            start_times.append(start_time)
-            stop_times.append(stop_time)
-            if i == 0:
-                continue
-            if start_time < stop_times[i - 1]:
-                clock_resets.append(i)
+        i = 0
+        for epoch_video_timestamps_file_paths in video_timestamps_file_paths:
+            if not isinstance(epoch_video_timestamps_file_paths, list):
+                epoch_video_timestamps_file_paths = [epoch_video_timestamps_file_paths]
+
+            for timestamp_file_path in epoch_video_timestamps_file_paths:
+                timestamps, _ = readCameraModuleTimeStamps(timestamp_file_path)
+
+                start_time = timestamps[0]
+                stop_time = timestamps[-1]
+                start_times.append(start_time)
+                stop_times.append(stop_time)
+                if i == 0:
+                    i += 1
+                    continue
+                if start_time < stop_times[i - 1]:
+                    clock_resets.append(i)
+                i += 1
 
         # Align interface timestamps
         video_interfaces = self.data_interface_objects["Video"].video_interfaces
-        aligned_timestamps, starting_time_shifts, clock_rates = [], [], []
-        for i, (video_timestamps_file_path, video_interface) in enumerate(
-            zip(video_timestamps_file_paths, video_interfaces)
-        ):
-            timestamps, clock_rate = readCameraModuleTimeStamps(video_timestamps_file_path)
-            starting_time_shift = 0.0
-            for reset_index in clock_resets:
-                if i >= reset_index:
-                    starting_time_shift += stop_times[reset_index - 1] + INTER_EPOCH_INTERVAL
-            timestamps += starting_time_shift
-            starting_time_shifts.append(starting_time_shift)
-            clock_rates.append(clock_rate)
+        aligned_timestamps, starting_time_shifts, clock_rates, starting_frames = [], [], [], []
+        i = 0
+        for epoch_video_timestamps_file_paths, video_interface in zip(video_timestamps_file_paths, video_interfaces):
+            if not isinstance(epoch_video_timestamps_file_paths, list):
+                epoch_video_timestamps_file_paths = [epoch_video_timestamps_file_paths]
 
-            video_interface.set_aligned_timestamps(aligned_timestamps=[timestamps])
-            if "DeepLabCut1" in self.data_interface_objects:
-                dlc1_interface = self.data_interface_objects["DeepLabCut1"].dlc_interfaces[i]
-                dlc1_interface.set_aligned_timestamps(aligned_timestamps=timestamps)
-            if "DeepLabCut2" in self.data_interface_objects:
-                dlc2_interface = self.data_interface_objects["DeepLabCut2"].dlc_interfaces[i]
-                dlc2_interface.set_aligned_timestamps(aligned_timestamps=timestamps)
-            aligned_timestamps.append(timestamps)
+            epoch_timestamps, epoch_clock_rates, epoch_starting_time_shifts, epoch_starting_frames = [], [], [], []
+            for segment_index, timestamp_file_path in enumerate(epoch_video_timestamps_file_paths):
+                timestamps, clock_rate = readCameraModuleTimeStamps(timestamp_file_path)
+
+                # Calculate starting time shift for this segment
+                starting_time_shift = 0.0
+                for reset_index in clock_resets:
+                    if i >= reset_index:
+                        starting_time_shift += stop_times[reset_index - 1] + INTER_EPOCH_INTERVAL
+                timestamps += starting_time_shift
+
+                # Calculate starting frame for this segment
+                starting_frame = 0
+                if segment_index > 0:
+                    starting_frame = epoch_starting_frames[segment_index - 1] + len(epoch_timestamps[segment_index - 1])
+
+                epoch_timestamps.append(timestamps)
+                epoch_clock_rates.append(clock_rate)
+                epoch_starting_time_shifts.append(starting_time_shift)
+                epoch_starting_frames.append(starting_frame)
+                i += 1
+            aligned_timestamps.append(epoch_timestamps)
+            starting_time_shifts.append(epoch_starting_time_shifts[0])
+            clock_rates.append(epoch_clock_rates[0])
+            starting_frames.append(epoch_starting_frames)
+
+            video_interface.set_aligned_timestamps(aligned_timestamps=epoch_timestamps)
+
+            # # For DLC interfaces, use the first timestamp array (assuming one DLC per epoch)
+            # if "DeepLabCut1" in self.data_interface_objects:
+            #     dlc1_interface = self.data_interface_objects["DeepLabCut1"].dlc_interfaces[i]
+            #     dlc1_interface.set_aligned_timestamps(aligned_timestamps=aligned_epoch_timestamps[0])
+            # if "DeepLabCut2" in self.data_interface_objects:
+            #     dlc2_interface = self.data_interface_objects["DeepLabCut2"].dlc_interfaces[i]
+            #     dlc2_interface.set_aligned_timestamps(aligned_timestamps=aligned_epoch_timestamps[0])
+
+        self.data_interface_objects["Video"].set_starting_frames(starting_frames=starting_frames)
         self.data_interface_objects["Epoch"].set_aligned_timestamps(aligned_timestamps=aligned_timestamps)
         self.data_interface_objects["Behavior"].set_epoch_starting_time_shifts(
             starting_time_shifts=starting_time_shifts

--- a/src/jadhav_lab_to_nwb/rivera_and_shukla_2025/rivera_and_shukla_2025_nwbconverter.py
+++ b/src/jadhav_lab_to_nwb/rivera_and_shukla_2025/rivera_and_shukla_2025_nwbconverter.py
@@ -41,11 +41,9 @@ class RiveraAndShukla2025NWBConverter(NWBConverter):
 
         # Align interface timestamps
         video_interfaces = self.data_interface_objects["Video"].video_interfaces
-        dlc1_interfaces = self.data_interface_objects["DeepLabCut1"].dlc_interfaces
-        dlc2_interfaces = self.data_interface_objects["DeepLabCut2"].dlc_interfaces
         aligned_timestamps, starting_time_shifts, clock_rates = [], [], []
-        for i, (video_timestamps_file_path, video_interface, dlc1_interface, dlc2_interface) in enumerate(
-            zip(video_timestamps_file_paths, video_interfaces, dlc1_interfaces, dlc2_interfaces)
+        for i, (video_timestamps_file_path, video_interface) in enumerate(
+            zip(video_timestamps_file_paths, video_interfaces)
         ):
             timestamps, clock_rate = readCameraModuleTimeStamps(video_timestamps_file_path)
             starting_time_shift = 0.0
@@ -57,8 +55,12 @@ class RiveraAndShukla2025NWBConverter(NWBConverter):
             clock_rates.append(clock_rate)
 
             video_interface.set_aligned_timestamps(aligned_timestamps=[timestamps])
-            dlc1_interface.set_aligned_timestamps(aligned_timestamps=timestamps)
-            dlc2_interface.set_aligned_timestamps(aligned_timestamps=timestamps)
+            if "DeepLabCut1" in self.data_interface_objects:
+                dlc1_interface = self.data_interface_objects["DeepLabCut1"].dlc_interfaces[i]
+                dlc1_interface.set_aligned_timestamps(aligned_timestamps=timestamps)
+            if "DeepLabCut2" in self.data_interface_objects:
+                dlc2_interface = self.data_interface_objects["DeepLabCut2"].dlc_interfaces[i]
+                dlc2_interface.set_aligned_timestamps(aligned_timestamps=timestamps)
             aligned_timestamps.append(timestamps)
         self.data_interface_objects["Epoch"].set_aligned_timestamps(aligned_timestamps=aligned_timestamps)
         self.data_interface_objects["Behavior"].set_epoch_starting_time_shifts(

--- a/src/jadhav_lab_to_nwb/rivera_and_shukla_2025/rivera_and_shukla_2025_nwbconverter.py
+++ b/src/jadhav_lab_to_nwb/rivera_and_shukla_2025/rivera_and_shukla_2025_nwbconverter.py
@@ -4,7 +4,6 @@ from pathlib import Path
 import pandas as pd
 import numpy as np
 import warnings
-from natsort import natsorted
 
 from jadhav_lab_to_nwb.rivera_and_shukla_2025 import (
     RiveraAndShukla2025BehaviorInterface,
@@ -29,25 +28,13 @@ class RiveraAndShukla2025NWBConverter(NWBConverter):
     )
 
     def temporally_align_data_interfaces(self, metadata: dict | None = None, conversion_options: dict | None = None):
-        if "DeepLabCut1" in self.data_interface_objects:
-            epoch_name_to_dlc1_interfaces = {}
-            for dlc_interface in self.data_interface_objects["DeepLabCut1"].dlc_interfaces:
-                file_path = Path(dlc_interface.source_data["file_path"])
-                epoch_name = rivera_and_shukla_2025_get_epoch_name(name=file_path.name)
-                if epoch_name not in epoch_name_to_dlc1_interfaces:
-                    epoch_name_to_dlc1_interfaces[epoch_name] = [dlc_interface]
-                else:
-                    epoch_name_to_dlc1_interfaces[epoch_name].append(dlc_interface)
-        if "DeepLabCut2" in self.data_interface_objects:
-            epoch_name_to_dlc2_interfaces = {}
-            for dlc_interface in self.data_interface_objects["DeepLabCut2"].dlc_interfaces:
-                file_path = Path(dlc_interface.source_data["file_path"])
-                epoch_name = rivera_and_shukla_2025_get_epoch_name(name=file_path.name)
-                if epoch_name not in epoch_name_to_dlc2_interfaces:
-                    epoch_name_to_dlc2_interfaces[epoch_name] = [dlc_interface]
-                else:
-                    epoch_name_to_dlc2_interfaces[epoch_name].append(dlc_interface)
+        aligned_timestamps, starting_time_shifts, clock_rates, starting_frames = self.get_aligned_timing()
+        self.align_video(aligned_timestamps=aligned_timestamps, starting_frames=starting_frames)
+        self.align_epoch(aligned_timestamps=aligned_timestamps)
+        self.align_behavior(starting_time_shifts=starting_time_shifts, clock_rates=clock_rates)
+        self.align_dlc()
 
+    def get_aligned_timing(self):
         video_timestamps_file_paths = self.data_interface_objects["Video"].video_timestamps_file_paths
 
         # Check for clock resets
@@ -72,18 +59,12 @@ class RiveraAndShukla2025NWBConverter(NWBConverter):
                     clock_resets.append(i)
                 i += 1
 
-        # Align interface timestamps
-        epoch_name_to_video_interface = {}
-        video_interfaces = self.data_interface_objects["Video"].video_interfaces
+        # Align timestamps with clock resets
         aligned_timestamps, starting_time_shifts, clock_rates, starting_frames = [], [], [], []
         i = 0
-        for epoch_video_timestamps_file_paths, video_interface in zip(
-            video_timestamps_file_paths, video_interfaces, strict=True
-        ):
+        for epoch_video_timestamps_file_paths in video_timestamps_file_paths:
             if not isinstance(epoch_video_timestamps_file_paths, list):
                 epoch_video_timestamps_file_paths = [epoch_video_timestamps_file_paths]
-            epoch_name = rivera_and_shukla_2025_get_epoch_name(name=Path(epoch_video_timestamps_file_paths[0]).name)
-            epoch_name_to_video_interface[epoch_name] = video_interface
 
             epoch_timestamps, epoch_clock_rates, epoch_starting_time_shifts, epoch_starting_frames = [], [], [], []
             for segment_index, timestamp_file_path in enumerate(epoch_video_timestamps_file_paths):
@@ -111,15 +92,30 @@ class RiveraAndShukla2025NWBConverter(NWBConverter):
             clock_rates.append(epoch_clock_rates[0])
             starting_frames.append(epoch_starting_frames)
 
-            video_interface.set_aligned_timestamps(aligned_timestamps=epoch_timestamps)
+        return (aligned_timestamps, starting_time_shifts, clock_rates, starting_frames)
 
+    def align_video(self, aligned_timestamps: list[list[np.ndarray]], starting_frames: list[list[int]]):
+        video_interfaces = self.data_interface_objects["Video"].video_interfaces
+        for video_interface, timestamps in zip(video_interfaces, aligned_timestamps, strict=True):
+            video_interface.set_aligned_timestamps(aligned_timestamps=timestamps)
         self.data_interface_objects["Video"].set_starting_frames(starting_frames=starting_frames)
-        self.data_interface_objects["Epoch"].set_aligned_timestamps(aligned_timestamps=aligned_timestamps)
-        self.data_interface_objects["Behavior"].set_epoch_starting_time_shifts(
-            starting_time_shifts=starting_time_shifts
-        )
-        self.data_interface_objects["Behavior"].set_clock_rates(clock_rates=clock_rates)
 
+    def align_epoch(self, aligned_timestamps: list[list[np.ndarray]]):
+        epoch_interface = self.data_interface_objects["Epoch"]
+        epoch_interface.set_aligned_timestamps(aligned_timestamps=aligned_timestamps)
+
+    def align_behavior(self, starting_time_shifts: list[float], clock_rates: list[float]):
+        behavior_interface = self.data_interface_objects["Behavior"]
+        behavior_interface.set_epoch_starting_time_shifts(starting_time_shifts=starting_time_shifts)
+        behavior_interface.set_clock_rates(clock_rates=clock_rates)
+
+    def align_dlc(self):
+        # Note, this method requires that the video interfaces have already been aligned.
+        (
+            epoch_name_to_dlc1_interfaces,
+            epoch_name_to_dlc2_interfaces,
+            epoch_name_to_video_interface,
+        ) = self.get_epoch_name_mappings()
         if "DeepLabCut1" in self.data_interface_objects:
             for epoch_name, dlc1_interfaces in epoch_name_to_dlc1_interfaces.items():
                 video_interface = epoch_name_to_video_interface[epoch_name]
@@ -132,6 +128,35 @@ class RiveraAndShukla2025NWBConverter(NWBConverter):
                 aligned_timestamps = video_interface.get_timestamps()
                 for dlc_interface, timestamps in zip(dlc2_interfaces, aligned_timestamps, strict=True):
                     self.align_dlc_interface(timestamps, dlc_interface)
+
+    def get_epoch_name_mappings(self):
+        epoch_name_to_dlc1_interfaces = {}
+        if "DeepLabCut1" in self.data_interface_objects:
+            for dlc_interface in self.data_interface_objects["DeepLabCut1"].dlc_interfaces:
+                file_path = Path(dlc_interface.source_data["file_path"])
+                epoch_name = rivera_and_shukla_2025_get_epoch_name(name=file_path.name)
+                if epoch_name not in epoch_name_to_dlc1_interfaces:
+                    epoch_name_to_dlc1_interfaces[epoch_name] = [dlc_interface]
+                else:
+                    epoch_name_to_dlc1_interfaces[epoch_name].append(dlc_interface)
+
+        epoch_name_to_dlc2_interfaces = {}
+        if "DeepLabCut2" in self.data_interface_objects:
+            for dlc_interface in self.data_interface_objects["DeepLabCut2"].dlc_interfaces:
+                file_path = Path(dlc_interface.source_data["file_path"])
+                epoch_name = rivera_and_shukla_2025_get_epoch_name(name=file_path.name)
+                if epoch_name not in epoch_name_to_dlc2_interfaces:
+                    epoch_name_to_dlc2_interfaces[epoch_name] = [dlc_interface]
+                else:
+                    epoch_name_to_dlc2_interfaces[epoch_name].append(dlc_interface)
+
+        epoch_name_to_video_interface = {}
+        for video_interface in self.data_interface_objects["Video"].video_interfaces:
+            file_path = Path(video_interface.source_data["file_paths"][0])
+            epoch_name = rivera_and_shukla_2025_get_epoch_name(name=file_path.name)
+            epoch_name_to_video_interface[epoch_name] = video_interface
+
+        return epoch_name_to_dlc1_interfaces, epoch_name_to_dlc2_interfaces, epoch_name_to_video_interface
 
     def align_dlc_interface(self, aligned_timestamps: np.ndarray, dlc_interface):
         file_path = Path(dlc_interface.source_data["file_path"])

--- a/src/jadhav_lab_to_nwb/rivera_and_shukla_2025/rivera_and_shukla_2025_nwbconverter.py
+++ b/src/jadhav_lab_to_nwb/rivera_and_shukla_2025/rivera_and_shukla_2025_nwbconverter.py
@@ -23,6 +23,7 @@ class RiveraAndShukla2025NWBConverter(NWBConverter):
     )
 
     def temporally_align_data_interfaces(self, metadata: dict | None = None, conversion_options: dict | None = None):
+        # TODO: Add support for multi-segment DLC and make sure changes don't break olson_2024
         video_timestamps_file_paths = self.data_interface_objects["Video"].video_timestamps_file_paths
 
         # Check for clock resets
@@ -75,6 +76,13 @@ class RiveraAndShukla2025NWBConverter(NWBConverter):
                 epoch_clock_rates.append(clock_rate)
                 epoch_starting_time_shifts.append(starting_time_shift)
                 epoch_starting_frames.append(starting_frame)
+
+                if "DeepLabCut1" in self.data_interface_objects:
+                    dlc1_interface = self.data_interface_objects["DeepLabCut1"].dlc_interfaces[i]
+                    dlc1_interface.set_aligned_timestamps(aligned_timestamps=timestamps)
+                if "DeepLabCut2" in self.data_interface_objects:
+                    dlc2_interface = self.data_interface_objects["DeepLabCut2"].dlc_interfaces[i]
+                    dlc2_interface.set_aligned_timestamps(aligned_timestamps=timestamps)
                 i += 1
             aligned_timestamps.append(epoch_timestamps)
             starting_time_shifts.append(epoch_starting_time_shifts[0])
@@ -82,14 +90,6 @@ class RiveraAndShukla2025NWBConverter(NWBConverter):
             starting_frames.append(epoch_starting_frames)
 
             video_interface.set_aligned_timestamps(aligned_timestamps=epoch_timestamps)
-
-            # # For DLC interfaces, use the first timestamp array (assuming one DLC per epoch)
-            # if "DeepLabCut1" in self.data_interface_objects:
-            #     dlc1_interface = self.data_interface_objects["DeepLabCut1"].dlc_interfaces[i]
-            #     dlc1_interface.set_aligned_timestamps(aligned_timestamps=aligned_epoch_timestamps[0])
-            # if "DeepLabCut2" in self.data_interface_objects:
-            #     dlc2_interface = self.data_interface_objects["DeepLabCut2"].dlc_interfaces[i]
-            #     dlc2_interface.set_aligned_timestamps(aligned_timestamps=aligned_epoch_timestamps[0])
 
         self.data_interface_objects["Video"].set_starting_frames(starting_frames=starting_frames)
         self.data_interface_objects["Epoch"].set_aligned_timestamps(aligned_timestamps=aligned_timestamps)

--- a/src/jadhav_lab_to_nwb/rivera_and_shukla_2025/rivera_and_shukla_2025_video_interface.py
+++ b/src/jadhav_lab_to_nwb/rivera_and_shukla_2025/rivera_and_shukla_2025_video_interface.py
@@ -18,4 +18,10 @@ class RiveraAndShukla2025VideoInterface(BaseVideoInterface):
             task_name = "SocialW_Left"
         elif metadata["Subject"]["subject_id"] == subject_id2:
             task_name = "SocialW_Right"
+        else:
+            message = (
+                f"Metadata subject ID {metadata['Subject']['subject_id']} does not match the expected subject IDs "
+                f"{subject_id1} or {subject_id2}."
+            )
+            raise ValueError(message)
         return task_name

--- a/src/jadhav_lab_to_nwb/spyglass_mock/nan_timestamps_bug.py
+++ b/src/jadhav_lab_to_nwb/spyglass_mock/nan_timestamps_bug.py
@@ -1,0 +1,89 @@
+"See Issue: https://github.com/LorenFrankLab/spyglass/issues/1323"
+from pynwb.testing.mock.file import mock_NWBFile, mock_Subject
+from pynwb import NWBHDF5IO
+import numpy as np
+from pathlib import Path
+
+from ndx_pose import (
+    PoseEstimationSeries,
+    PoseEstimation,
+    Skeleton,
+    Skeletons,
+)
+
+
+def add_pose_estimation(nwbfile):
+    subject = mock_Subject(nwbfile=nwbfile)
+    skeleton = Skeleton(
+        name="subject1_skeleton",
+        nodes=["front_left_paw", "body", "front_right_paw"],
+        edges=np.array([[0, 1], [1, 2]], dtype="uint8"),
+        subject=subject,
+    )
+    skeletons = Skeletons(skeletons=[skeleton])
+
+    data = np.random.rand(100, 2)  # num_frames x (x, y) but can be (x, y, z)
+    confidence = np.random.rand(100)  # a confidence value for every frame
+    timestamps = np.ones(100) * np.nan  # intentionally set to NaN to simulate the bug
+    reference_frame = "(0,0) corresponds to top left corner"
+    confidence_definition = "Softmax output of the deep neural network."
+
+    pose_estimation_series = [
+        PoseEstimationSeries(
+            name="PoseEstimationSeries",
+            description="Test data with starting time and rate instead of timestamps.",
+            data=data,
+            reference_frame=reference_frame,
+            timestamps=timestamps,
+            confidence=confidence,
+            confidence_definition=confidence_definition,
+        ),
+    ]
+    pose_estimation = PoseEstimation(
+        name="PoseEstimation",
+        pose_estimation_series=pose_estimation_series,
+        description="Estimated positions of front paws of subject1 using DeepLabCut.",
+        skeleton=skeleton,
+    )
+
+    behavior_module = nwbfile.create_processing_module(name="behavior", description="behavior module")
+    behavior_module.add(pose_estimation)
+    behavior_module.add(skeletons)
+
+
+def write_nwbfile():
+    nwbfile = mock_NWBFile(identifier="my_identifier", session_description="my_session_description")
+    add_pose_estimation(nwbfile)
+
+    nwbfile_path = Path("/Volumes/T7/CatalystNeuro/Spyglass/raw/nan_timestamps_bug.nwb")
+    if nwbfile_path.exists():
+        nwbfile_path.unlink()
+    with NWBHDF5IO(nwbfile_path, "w") as io:
+        io.write(nwbfile)
+    print(f"NWB file successfully written at {nwbfile_path}")
+
+
+def add_to_spyglass():
+    import datajoint as dj
+
+    dj_local_conf_path = "/Users/pauladkisson/Documents/CatalystNeuro/JadhavConv/jadhav-lab-to-nwb/src/jadhav_lab_to_nwb/spyglass_mock/dj_local_conf.json"
+    dj.config.load(dj_local_conf_path)  # load config for database connection info
+
+    # spyglass.common has the most frequently used tables
+    import spyglass.common as sgc  # this import connects to the database
+
+    # spyglass.data_import has tools for inserting NWB files into the database
+    import spyglass.data_import as sgi
+    from spyglass.utils.nwb_helper_fn import get_nwb_copy_filename
+
+    nwbfile_path = Path("/Volumes/T7/CatalystNeuro/Spyglass/raw/nan_timestamps_bug.nwb")
+    nwb_copy_file_name = get_nwb_copy_filename(nwbfile_path.name)
+
+    if sgc.Nwbfile & {"nwb_file_name": nwb_copy_file_name}:
+        (sgc.Nwbfile & {"nwb_file_name": nwb_copy_file_name}).delete()
+    sgi.insert_sessions(str(nwbfile_path), rollback_on_fail=True, raise_err=True)
+
+
+if __name__ == "__main__":
+    write_nwbfile()
+    add_to_spyglass()

--- a/src/jadhav_lab_to_nwb/spyglass_mock/rate_based_pose_estimation_bug.py
+++ b/src/jadhav_lab_to_nwb/spyglass_mock/rate_based_pose_estimation_bug.py
@@ -1,0 +1,89 @@
+"See Issue: https://github.com/LorenFrankLab/spyglass/issues/1321"
+from pynwb.testing.mock.file import mock_NWBFile, mock_Subject
+from pynwb import NWBHDF5IO
+import numpy as np
+from pathlib import Path
+
+from ndx_pose import (
+    PoseEstimationSeries,
+    PoseEstimation,
+    Skeleton,
+    Skeletons,
+)
+
+
+def add_pose_estimation(nwbfile):
+    subject = mock_Subject(nwbfile=nwbfile)
+    skeleton = Skeleton(
+        name="subject1_skeleton",
+        nodes=["front_left_paw", "body", "front_right_paw"],
+        edges=np.array([[0, 1], [1, 2]], dtype="uint8"),
+        subject=subject,
+    )
+    skeletons = Skeletons(skeletons=[skeleton])
+
+    data = np.random.rand(100, 2)  # num_frames x (x, y) but can be (x, y, z)
+    confidence = np.random.rand(100)  # a confidence value for every frame
+    reference_frame = "(0,0) corresponds to top left corner"
+    confidence_definition = "Softmax output of the deep neural network."
+
+    pose_estimation_series = [
+        PoseEstimationSeries(
+            name="PoseEstimationSeries",
+            description="Test data with starting time and rate instead of timestamps.",
+            data=data,
+            reference_frame=reference_frame,
+            starting_time=0.0,
+            rate=30.0,
+            confidence=confidence,
+            confidence_definition=confidence_definition,
+        ),
+    ]
+    pose_estimation = PoseEstimation(
+        name="PoseEstimation",
+        pose_estimation_series=pose_estimation_series,
+        description="Estimated positions of front paws of subject1 using DeepLabCut.",
+        skeleton=skeleton,
+    )
+
+    behavior_module = nwbfile.create_processing_module(name="behavior", description="behavior module")
+    behavior_module.add(pose_estimation)
+    behavior_module.add(skeletons)
+
+
+def write_nwbfile():
+    nwbfile = mock_NWBFile(identifier="my_identifier", session_description="my_session_description")
+    add_pose_estimation(nwbfile)
+
+    nwbfile_path = Path("/Volumes/T7/CatalystNeuro/Spyglass/raw/rate_based_pose_estimation_bug.nwb")
+    if nwbfile_path.exists():
+        nwbfile_path.unlink()
+    with NWBHDF5IO(nwbfile_path, "w") as io:
+        io.write(nwbfile)
+    print(f"NWB file successfully written at {nwbfile_path}")
+
+
+def add_to_spyglass():
+    import datajoint as dj
+
+    dj_local_conf_path = "/Users/pauladkisson/Documents/CatalystNeuro/JadhavConv/jadhav-lab-to-nwb/src/jadhav_lab_to_nwb/spyglass_mock/dj_local_conf.json"
+    dj.config.load(dj_local_conf_path)  # load config for database connection info
+
+    # spyglass.common has the most frequently used tables
+    import spyglass.common as sgc  # this import connects to the database
+
+    # spyglass.data_import has tools for inserting NWB files into the database
+    import spyglass.data_import as sgi
+    from spyglass.utils.nwb_helper_fn import get_nwb_copy_filename
+
+    nwbfile_path = Path("/Volumes/T7/CatalystNeuro/Spyglass/raw/rate_based_pose_estimation_bug.nwb")
+    nwb_copy_file_name = get_nwb_copy_filename(nwbfile_path.name)
+
+    if sgc.Nwbfile & {"nwb_file_name": nwb_copy_file_name}:
+        (sgc.Nwbfile & {"nwb_file_name": nwb_copy_file_name}).delete()
+    sgi.insert_sessions(str(nwbfile_path), rollback_on_fail=True, raise_err=True)
+
+
+if __name__ == "__main__":
+    write_nwbfile()
+    add_to_spyglass()

--- a/src/jadhav_lab_to_nwb/tools/spikeinterface.py
+++ b/src/jadhav_lab_to_nwb/tools/spikeinterface.py
@@ -148,7 +148,6 @@ def add_electrode_groups_to_nwbfile(recording: BaseRecording, nwbfile: pynwb.NWB
         shanks_electrodes = group_name_to_shanks_electrodes[group_name]
         shank = Shank(name="0", shanks_electrodes=shanks_electrodes)
         probe_name = group_metadata.get("probe_name", f"{group_name}_probe")
-        # TODO: Condense probe types and descriptions once https://github.com/LorenFrankLab/spyglass/issues/1216 is fixed.
         probe_type = group_metadata.get("probe_type", f"{group_name}_probe_type")
         probe_units = group_metadata.get("probe_units", "unknown")
         probe_description = group_metadata.get("probe_description", f"{probe_name} description")


### PR DESCRIPTION
This PR adds several example sessions, implements the convert_all_sessions script, and implements the insert_all_sessions script which inserts all of the converted sessions into a spyglass db.

It also adds fixes for the following edge cases:
- [x] Some sessions have multiple segments / epoch --> Updated interface to support multi-segment
- [x] Some sessions have corrupted DLC files --> skipping those
- [x] Some of the sessions have a different number of timestamps for video and dlc --> setting dlc timestamps to NaN
- [x] One of the sessions have incomplete epochs --> skipping
- [x] Some of the sessions are missing DLC epochs/segments --> skipping dlc for missing epochs/segments

Unfortunately, Spyglass doesn't support NaNs for the timestamps of DLC, so I opened an issue to discuss the matter here: https://github.com/LorenFrankLab/spyglass/issues/1323